### PR TITLE
Fix Yandex script loading

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -224,7 +224,7 @@ export default async function RootLayout({
 
         {/* Яндекс Метрика */}
         {ymId && (
-          <Script id="yandex-metrika" strategy="afterInteractive">
+          <Script id="yandex-metrika" strategy="lazyOnload">
             {`
               (function(m,e,t,r,i,k,a){
                 m[i]=m[i]||function(){
@@ -252,7 +252,7 @@ export default async function RootLayout({
 
         {/* Яндекс Турбо */}
         {ymId && (
-          <Script id="yandex-turbo" strategy="afterInteractive">
+          <Script id="yandex-turbo" strategy="lazyOnload">
             {`
               (function() {
                 var turboScript = document.createElement('script');


### PR DESCRIPTION
## Summary
- load Yandex.Metrika script with `lazyOnload`
- load Yandex Turbo script with `lazyOnload`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417cc99c8c8320b676ecd9a869c120