### PR TITLE
Fix redundant NODE_ENV comparisons

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -22,7 +22,7 @@ export default async function Header() {
     .order('id', { ascending: true });
 
   if (error) {
-    process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "production" && console.error(`${new Date().toISOString()} Header: Error loading categories`, error);
+    process.env.NODE_ENV !== "production" && console.error(`${new Date().toISOString()} Header: Error loading categories`, error);
   }
 
   // Форматируем данные категорий

--- a/components/admin/ProductForm.tsx
+++ b/components/admin/ProductForm.tsx
@@ -52,7 +52,7 @@ export default function ProductForm({ product, onClose, onSave }: ProductFormPro
       .eq('is_visible', true);
 
     if (error) {
-      process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "production" && console.error('Error fetching categories:', error);
+      process.env.NODE_ENV !== "production" && console.error('Error fetching categories:', error);
       return;
     }
 
@@ -66,7 +66,7 @@ export default function ProductForm({ product, onClose, onSave }: ProductFormPro
       .eq('is_visible', true);
 
     if (error) {
-      process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "production" && console.error('Error fetching subcategories:', error);
+      process.env.NODE_ENV !== "production" && console.error('Error fetching subcategories:', error);
       return;
     }
 
@@ -81,7 +81,7 @@ export default function ProductForm({ product, onClose, onSave }: ProductFormPro
       .eq('product_id', product.id);
 
     if (error) {
-      process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "production" && console.error('Error fetching product categories:', error);
+      process.env.NODE_ENV !== "production" && console.error('Error fetching product categories:', error);
       return;
     }
 
@@ -99,7 +99,7 @@ export default function ProductForm({ product, onClose, onSave }: ProductFormPro
       .eq('product_id', product.id);
 
     if (error) {
-      process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "production" && console.error('Error fetching product subcategories:', error);
+      process.env.NODE_ENV !== "production" && console.error('Error fetching product subcategories:', error);
       return;
     }
 


### PR DESCRIPTION
## Summary
- clean up environment checks in Header
- clean up environment checks in ProductForm admin component

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419726ac2483209ca400fd3f1e4d4d