### PR TITLE
Update product validation type

### DIFF
--- a/components/admin/ProductForm.tsx
+++ b/components/admin/ProductForm.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { supabasePublic } from '@/lib/supabase/client';
-import { slugify, validateProduct } from '@/lib/utils';
+import { slugify, validateProduct, type ProductData } from '@/lib/utils';
 import type { Tables } from '@/lib/supabase/types_new';
 import Image from 'next/image';
 
@@ -132,7 +132,7 @@ export default function ProductForm({ product, onClose, onSave }: ProductFormPro
     e.preventDefault();
     setError('');
 
-    const validationError = validateProduct(formData);
+    const validationError = validateProduct(formData as ProductData);
     if (validationError) {
       setError(validationError);
       return;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,9 @@
-export function validateProduct(data: any): string | null {
+export interface ProductData {
+  title: string;
+  price: number;
+}
+
+export function validateProduct(data: ProductData): string | null {
   if (!data.title || data.title.length < 3) {
     return 'Название должно быть не короче 3 символов';
   }


### PR DESCRIPTION
## Summary
- add `ProductData` interface for validating products
- use `ProductData` in `validateProduct`
- update admin product form to cast to `ProductData`

## Testing
- `npm ci`
- `npm run lint` *(fails: numerous lint errors)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68419cf98bb483209c21915e2f648401