### PR TITLE
Fix removeEventListener options

### DIFF
--- a/components/StickyHeader.tsx
+++ b/components/StickyHeader.tsx
@@ -213,7 +213,7 @@ export default function StickyHeader({ initialCategories }: StickyHeaderProps) {
     window.addEventListener('scroll', updatePos, { passive: true });
     return () => {
       window.removeEventListener('resize', updatePos);
-      window.removeEventListener('scroll', updatePos, { passive: true });
+      window.removeEventListener('scroll', updatePos);
     };
   }, [setCartIconPosition]);
 


### PR DESCRIPTION
## Summary
- fix TypeScript error for `removeEventListener`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a9a108688320be20907f90f3b5f6