### PR TITLE
Remove redundant AdminLayout imports from promo pages

### DIFF
--- a/app/admin/(protected)/promo-codes/page.tsx
+++ b/app/admin/(protected)/promo-codes/page.tsx
@@ -3,7 +3,6 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import AdminLayout from '../layout';  
 import toast from 'react-hot-toast';
 import { motion } from 'framer-motion';
 import CSRFToken from '@components/CSRFToken';
@@ -200,8 +199,7 @@ export default function PromoCodesAdminPage() {
   if (!isAuthenticated) return null;
 
   return (
-    <AdminLayout>
-      <CSRFToken>
+    <CSRFToken>
         {(csrfToken) => (
           <motion.div
             className="max-w-4xl mx-auto py-10 px-4"
@@ -428,6 +426,5 @@ export default function PromoCodesAdminPage() {
           </motion.div>
         )}
       </CSRFToken>
-    </AdminLayout>
   );
 }

--- a/app/admin/(protected)/promo/page.tsx
+++ b/app/admin/(protected)/promo/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
-import AdminLayout from '../layout';  
 import toast from 'react-hot-toast';
 import { motion } from 'framer-motion';
 import CSRFToken from '@components/CSRFToken';
@@ -242,8 +241,7 @@ export default function PromoAdminPage() {
   if (!isAuthenticated) return null;
 
   return (
-    <AdminLayout>
-      <CSRFToken>
+    <CSRFToken>
         {(csrfToken) => (
           <motion.div
             className="max-w-4xl mx-auto py-10 px-4"
@@ -531,6 +529,5 @@ export default function PromoAdminPage() {
           </motion.div>
         )}
       </CSRFToken>
-    </AdminLayout>
   );
 }


### PR DESCRIPTION
## Summary
- drop unused `AdminLayout` import from admin promo pages
- eliminate manual `<AdminLayout>` wrapper so default layout applies automatically

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e4ed525c8320a66e0503029c4afd