### PR TITLE
Rename CategoryPreviewServer to CategoryPreviewWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 ```
 
 Without this value the `/api/upsell/products` endpoint will return an error.
+
+## Components
+
+### CategoryPreviewWrapper
+
+`CategoryPreviewWrapper` is a thin client wrapper around `CategoryPreviewClient` that prepares product data. The file lives in `components/CategoryPreviewWrapper.tsx` and includes the `'use client'` directive.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import type { ItemList } from 'schema-dts';
 import PromoGrid from '@components/PromoGrid';
 import AdvantagesClient from '@components/AdvantagesClient'; // <-- импорт Client версии
 import PopularProducts from '@components/PopularProducts';
-import CategoryPreviewServer from '@components/CategoryPreviewServer';
+import CategoryPreviewWrapper from '@components/CategoryPreviewWrapper';
 import SkeletonCard from '@components/ProductCardSkeleton';
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
@@ -206,7 +206,7 @@ export default async function Home() {
 
             return (
               <React.Fragment key={category}>
-                <CategoryPreviewServer
+                <CategoryPreviewWrapper
                   categoryName={category}
                   products={items}
                   seeMoreLink={slug}

--- a/components/CategoryPreviewWrapper.tsx
+++ b/components/CategoryPreviewWrapper.tsx
@@ -3,7 +3,8 @@
 import CategoryPreviewClient from '@components/CategoryPreviewClient';
 import { Product } from '@/types/product'; // Импортируем тип Product
 
-export default function CategoryPreviewServer({
+// Wrapper component for CategoryPreviewClient
+export default function CategoryPreviewWrapper({
   categoryName,
   products,
   seeMoreLink,


### PR DESCRIPTION
## Summary
- rename CategoryPreviewServer component to CategoryPreviewWrapper
- update imports and usages to the new name
- document the wrapper in README

## Testing
- `npm install`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843ea08f6f88320b903054b217d054c