### PR TITLE
Remove role attribute from TrackedLink

### DIFF
--- a/components/TrackedLink.tsx
+++ b/components/TrackedLink.tsx
@@ -49,7 +49,6 @@ export default function TrackedLink({
         aria-label={ariaLabel}
         target={target}
         rel={rel}
-        role="link"
         onClick={handleClick}
       >
         {children}


### PR DESCRIPTION
## Summary
- remove the extra `role="link"` attribute from `components/TrackedLink.tsx`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843eef329b4832091b2d7c4cb3a7a69