### PR TITLE
Fix gray text contrast

### DIFF
--- a/app/cart/components/CartItem.tsx
+++ b/app/cart/components/CartItem.tsx
@@ -71,7 +71,7 @@ export default function CartItem({
               <motion.button
                 onClick={handleMinus}
                 disabled={item.quantity <= 1}
-                className="w-8 h-8 flex items-center justify-center text-gray-400 hover:text-black transition disabled:opacity-50"
+                className="w-8 h-8 flex items-center justify-center text-gray-600 hover:text-black transition disabled:opacity-50"
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.9 }}
                 aria-label="Уменьшить количество"
@@ -82,7 +82,7 @@ export default function CartItem({
               <span className="px-3 text-base">{item.quantity}</span>
               <motion.button
                 onClick={handlePlus}
-                className="w-8 h-8 flex items-center justify-center text-gray-400 hover:text-black transition"
+                className="w-8 h-8 flex items-center justify-center text-gray-600 hover:text-black transition"
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.9 }}
                 aria-label="Увеличить количество"
@@ -94,7 +94,7 @@ export default function CartItem({
           )}
           <motion.button
             onClick={handleRemove}
-            className="text-gray-400 hover:text-red-500 transition ml-2"
+            className="text-gray-600 hover:text-red-500 transition ml-2"
             whileHover={{ scale: 1.1 }}
             whileTap={{ scale: 0.9 }}
             aria-label="Удалить товар из корзины"

--- a/app/cart/components/ThankYouModal.tsx
+++ b/app/cart/components/ThankYouModal.tsx
@@ -91,7 +91,7 @@ export default function ThankYouModal({ onClose, orderNumber, trackingUrl }: Pro
         >
           <motion.button
             onClick={onClose}
-            className="absolute right-4 top-4 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-black p-1"
+            className="absolute right-4 top-4 text-gray-600 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-black p-1"
             aria-label="Закрыть модальное окно"
             whileHover={{ scale: 1.1 }}
             whileTap={{ scale: 0.9 }}

--- a/app/cart/components/UpsellModal.tsx
+++ b/app/cart/components/UpsellModal.tsx
@@ -88,7 +88,7 @@ export default function UpsellModal({ type, onClose, onSelect }: Props) {
         >
           <motion.button
             onClick={onClose}
-            className="absolute top-4 right-4 text-gray-400 hover:text-black text-2xl focus:outline-none focus:ring-2 focus:ring-black"
+            className="absolute top-4 right-4 text-gray-600 hover:text-black text-2xl focus:outline-none focus:ring-2 focus:ring-black"
             aria-label="Закрыть модальное окно"
             whileHover={{ scale: 1.1 }}
             whileTap={{ scale: 0.9 }}

--- a/app/cart/components/steps/Step1ContactDetails.tsx
+++ b/app/cart/components/steps/Step1ContactDetails.tsx
@@ -52,7 +52,7 @@ export default function Step1ContactDetails({
           Телефон
         </label>
         <div className="relative">
-          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-600">
             <Image src="/icons/phone.svg" alt="Телефон" width={16} height={16} loading="lazy" />
           </div>
           <input
@@ -83,7 +83,7 @@ export default function Step1ContactDetails({
           Ваше имя
         </label>
         <div className="relative">
-          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-600">
             <Image src="/icons/user.svg" alt="Имя" width={16} height={16} loading="lazy" />
           </div>
           <input
@@ -113,7 +113,7 @@ export default function Step1ContactDetails({
           E-mail (необязательно)
         </label>
         <div className="relative">
-          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-600">
             <Image src="/icons/envelope.svg" alt="Email" width={16} height={16} loading="lazy" />
           </div>
           <input

--- a/app/cart/components/steps/Step2RecipientDetails.tsx
+++ b/app/cart/components/steps/Step2RecipientDetails.tsx
@@ -93,7 +93,7 @@ export default function Step2RecipientDetails({
           Имя получателя <span className="text-red-500">*</span>
         </label>
         <div className="relative">
-          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-600">
             <Image src="/icons/user.svg" alt="Имя" width={16} height={16} />
           </div>
           <input

--- a/app/cart/components/steps/Step3Address.tsx
+++ b/app/cart/components/steps/Step3Address.tsx
@@ -88,7 +88,7 @@ export default function Step3Address({
               Улица
             </label>
             <div className="relative">
-              <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+              <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-600">
                 <Image src="/icons/map-marker-alt.svg" alt="Улица" width={16} height={16} />
               </div>
               <input

--- a/app/cart/components/steps/Step4DateTime.tsx
+++ b/app/cart/components/steps/Step4DateTime.tsx
@@ -271,7 +271,7 @@ export default function Step4DateTime({
           Дата
         </label>
         <div className="relative">
-          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-600">
             <Image src="/icons/calendar-alt.svg" alt="Дата" width={16} height={16} />
           </div>
           <input
@@ -302,7 +302,7 @@ export default function Step4DateTime({
           Время
         </label>
         <div className="relative">
-          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+          <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-600">
             <Image src="/icons/clock.svg" alt="Время" width={16} height={16} />
           </div>
           <input

--- a/app/product/[id]/ProductPageClient.tsx
+++ b/app/product/[id]/ProductPageClient.tsx
@@ -458,7 +458,7 @@ export default function ProductPageClient({ product, combos }: { product: Produc
                 <span className="text-base sm:text-lg text-black font-medium ml-3 flex items-center gap-1">
                   + бонус {bonus}₽
                   <span
-                    className="ml-1 text-gray-400 cursor-pointer"
+                    className="ml-1 text-gray-600 cursor-pointer"
                     title="Бонус за оплату заказа, начисляется на бонусный счёт клиента"
                   >ⓘ</span>
                 </span>

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -224,7 +224,7 @@ function Breadcrumbs({ productTitle }: { productTitle?: string }) {
           {crumbs.map((c, i) => (
             <Fragment key={c.href}>
               {i > 0 && (
-                <span aria-hidden="true" className="mx-1 text-gray-400">
+                <span aria-hidden="true" className="mx-1 text-gray-500">
                   /
                 </span>
               )}
@@ -282,7 +282,7 @@ function SubcategoryCrumb({ categories }: { categories: Category[] }) {
     if (subcategory) {
       return (
         <li role="listitem" className="flex gap-2">
-          <span aria-hidden="true" className="mx-1 text-gray-400">/</span>
+          <span aria-hidden="true" className="mx-1 text-gray-500">/</span>
           <span className="text-black font-medium" aria-current="page">
             {subcategory.name}
           </span>

--- a/components/CustomerStories.tsx
+++ b/components/CustomerStories.tsx
@@ -133,7 +133,7 @@ export default function CustomerStories() {
               <div className="p-4">
                 <p className="text-sm text-gray-600 mb-2 line-clamp-3">{story.review}</p>
                 <p className="text-sm font-semibold text-black">{story.customer_name}</p>
-                <p className="text-xs text-gray-400">{new Date(story.date).toLocaleDateString('ru-RU')}</p>
+                <p className="text-xs text-gray-600">{new Date(story.date).toLocaleDateString('ru-RU')}</p>
               </div>
             </motion.div>
           );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -72,7 +72,7 @@ export default function Footer({ categories }: FooterProps) {
           >
             Рейтинг на Яндекс.Картах
           </a>
-          <p className="text-xs text-gray-400 mt-4">© 2025 KeyToHeart. Все права защищены.</p>
+          <p className="text-xs text-gray-600 mt-4">© 2025 KeyToHeart. Все права защищены.</p>
           <div className="mt-2 space-y-1">
             <Link
               href="/policy"
@@ -283,7 +283,7 @@ export default function Footer({ categories }: FooterProps) {
       {/* СЕРЫЙ блок о разработчике */}
       <div className="border-t border-gray-100">
         <div className="max-w-7xl mx-auto px-4 py-3 flex flex-col sm:flex-row items-center justify-between gap-2">
-          <span className="text-xs text-gray-400 font-mono">
+          <span className="text-xs text-gray-600 font-mono">
             Разработчик: Рыбалко Денис
           </span>
           <a

--- a/components/StickyHeader.tsx
+++ b/components/StickyHeader.tsx
@@ -300,7 +300,7 @@ export default function StickyHeader({ initialCategories }: StickyHeaderProps) {
                 >
                   +7 (988) 603-38-21
                 </a>
-                <span className="text-xs text-gray-400">с 08:00 до 22:00</span>
+                <span className="text-xs text-gray-600">с 08:00 до 22:00</span>
               </div>
               <div className="flex items-center gap-2">
                 <a
@@ -481,7 +481,7 @@ export default function StickyHeader({ initialCategories }: StickyHeaderProps) {
               </motion.div>
               <motion.button
                 onClick={() => setIsSearchOpen(false)}
-                className="absolute top-4 right-4 text-gray-400 hover:text-black focus:ring-2 focus:ring-black"
+                className="absolute top-4 right-4 text-gray-600 hover:text-black focus:ring-2 focus:ring-black"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}


### PR DESCRIPTION
## Summary
- darken footer legal text and developer credit
- darken product page bonus info icon
- improve contrast for input icons across checkout steps
- update cart item controls and modal buttons
- darken breadcrumbs separators and header info text
- tweak close buttons in modals
- darken dates in customer stories

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ef0bc11883208d7f9bd0eac0646f