### PR TITLE
Fix homepage import path

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import type { ItemList } from 'schema-dts';
 import PromoGrid from '@components/PromoGrid';
 import AdvantagesClient from '@components/AdvantagesClient'; // <-- импорт Client версии
 import PopularProductsServer from '@components/PopularProductsServer';
-import CategoryPreviewServer from '@components/CategoryPreviewServer';
+import CategoryPreviewWrapper from '@components/CategoryPreviewWrapper';
 import SkeletonCard from '@components/ProductCardSkeleton';
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';


### PR DESCRIPTION
## Summary
- correct CategoryPreview import in homepage

## Testing
- `npm run build` *(fails: @prisma/client did not initialize)*

------
https://chatgpt.com/codex/tasks/task_e_6843f1301dcc8320b54324c5ff91fa33