### PR TITLE
Fix mobile grid layout on category pages

### DIFF
--- a/app/category/[category]/CategoryPageClient.tsx
+++ b/app/category/[category]/CategoryPageClient.tsx
@@ -127,7 +127,7 @@ export default function CategoryPageClient({
         </p>
       ) : (
         <motion.div
-          className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
+          className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 0.5 }}


### PR DESCRIPTION
## Summary
- show two items per row on mobile category pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68449f5ce68c83209b5c5a27f9b75669