### PR TITLE
Remove hardcoded user name

### DIFF
--- a/components/account/PersonalForm.tsx
+++ b/components/account/PersonalForm.tsx
@@ -18,7 +18,7 @@ interface ProfileData {
 }
 
 export default function PersonalForm({ onUpdate, phone }: PersonalFormProps) {
-  const [name, setName] = useState<string>('Денис');
+  const [name, setName] = useState<string>('');
   const [lastName, setLastName] = useState<string>('');
   const [email, setEmail] = useState<string>('');
   const [birthday, setBirthday] = useState<string>('');
@@ -40,7 +40,7 @@ export default function PersonalForm({ onUpdate, phone }: PersonalFormProps) {
         const data = await res.json();
         if (data.success && data.data) {
           const profileData: ProfileData = data.data;
-          setName(profileData.name || 'Денис');
+          setName(profileData.name || '');
           setLastName(profileData.last_name || '');
           setEmail(profileData.email || '');
           setBirthday(profileData.birthday || '');


### PR DESCRIPTION
## Summary
- ensure PersonalForm initializes with an empty name
- fall back to an empty name when profile data lacks one

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a4b3100c832088406b76a2e20fee