### PR TITLE
Enable popular products

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import { JsonLd } from 'react-schemaorg';
 import type { ItemList } from 'schema-dts';
 import PromoGrid from '@components/PromoGrid';
 import AdvantagesClient from '@components/AdvantagesClient'; // <-- импорт Client версии
-// import PopularProductsServer from '@components/PopularProductsServer';
+import PopularProductsServer from '@components/PopularProductsServer';
 import CategoryPreviewWrapper from '@components/CategoryPreviewWrapper';
 import SkeletonCard from '@components/ProductCardSkeleton';
 import { createServerClient } from '@supabase/ssr';
@@ -186,15 +186,9 @@ export default async function Home() {
       <section>
         <PromoGrid />
       </section>
-      {/**
-       * Temporarily disable popular products for Lighthouse testing.
-       * Uncomment the section below to restore popular products.
-       */}
-      {/*
       <section>
         <PopularProductsServer />
       </section>
-      */}
       {/* AdvantagesServer убираем если используем AdvantagesClient */}
       <section aria-label="Категории товаров">
         {products.length === 0 ? (


### PR DESCRIPTION
## Summary
- uncomment PopularProductsServer section in home page

## Testing
- `npm install`
- `npx next lint` *(fails: various pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844aab11b708320a9edf2e7192bb36f