### PR TITLE
Fix subcategory dropdown placement

### DIFF
--- a/components/CategoryNav.tsx
+++ b/components/CategoryNav.tsx
@@ -216,7 +216,7 @@ export default function CategoryNav({ initialCategories }: { initialCategories: 
 
             return (
               <li key={cat.id} className="flex items-center">
-                <div className="group inline-block">
+                <div className="relative group inline-block">
                   <Link
                     href={href}
                     className={`px-2 py-1 text-sm font-medium transition-colors ${


### PR DESCRIPTION
## Summary
- make submenu relative to each category item

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844af593e5c8320818f8223c0c72231