### PR TITLE
Ensure eager loading for above-the-fold images

### DIFF
--- a/components/ContactsPageClient.tsx
+++ b/components/ContactsPageClient.tsx
@@ -127,7 +127,7 @@ export default function ContactsPageClient() {
             src="https://static-maps.yandex.ru/1.x/?lang=ru_RU&ll=39.042147,45.059956&z=17&l=map&pt=39.042147,45.059956,pm2rdl"
             alt="Магазин Ключ к Сердцу на карте"
             className="w-full h-[320px] sm:h-[400px] object-cover"
-            loading="lazy"
+            loading="eager"
             width={450}
             height={450}
             unoptimized

--- a/components/DostavkaPageClient.tsx
+++ b/components/DostavkaPageClient.tsx
@@ -41,7 +41,7 @@ export default function DostavkaPageClient() {
                 alt="Доставка клубничных букетов по Краснодару"
                 fill
                 className="object-cover rounded-lg"
-                loading="lazy"
+                loading="eager"
                 sizes="(max-width: 768px) 100vw, 50vw"
               />
             </div>
@@ -93,7 +93,7 @@ export default function DostavkaPageClient() {
                 alt="Самовывоз клубничных букетов в Краснодаре"
                 fill
                 className="object-cover rounded-lg"
-                loading="lazy"
+                loading="eager"
                 sizes="(max-width: 768px) 100vw, 50vw"
               />
             </div>

--- a/components/PaymentPageClient.tsx
+++ b/components/PaymentPageClient.tsx
@@ -64,7 +64,7 @@ export default function PaymentPageClient() {
                 width={24}
                 height={24}
                 className="flex-shrink-0"
-                loading="lazy"
+                loading="eager"
                 sizes="(max-width: 640px) 24px, 24px"
               />
               <div>
@@ -86,7 +86,7 @@ export default function PaymentPageClient() {
               width={24}
               height={24}
               className="flex-shrink-0"
-              loading="lazy"
+              loading="eager"
               sizes="(max-width: 640px) 24px, 24px"
             />
             <div>

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -114,7 +114,7 @@ export default function ProductCard({
           fill
           className="object-cover w-full h-full transition-transform duration-200 hover:scale-105"
           sizes="(max-width: 640px) 100vw, 280px"
-          loading="lazy"
+          loading={priority ? 'eager' : 'lazy'}
           priority={priority}
         />
         {!isMobile && images.length > 1 && (

--- a/components/StickyHeader.tsx
+++ b/components/StickyHeader.tsx
@@ -310,7 +310,7 @@ export default function StickyHeader({ initialCategories }: StickyHeaderProps) {
                   aria-label="Перейти в WhatsApp"
                   rel="nofollow"
                 >
-                  <Image src="/icons/whatsapp.svg" alt="WhatsApp" width={16} height={16} loading="lazy" />
+                  <Image src="/icons/whatsapp.svg" alt="WhatsApp" width={16} height={16} loading="eager" />
                 </a>
                 <a
                   href="https://t.me/keytomyheart"
@@ -319,7 +319,7 @@ export default function StickyHeader({ initialCategories }: StickyHeaderProps) {
                   aria-label="Перейти в Telegram"
                   rel="nofollow"
                 >
-                  <Image src="/icons/telegram.svg" alt="Telegram" width={16} height={16} loading="lazy" />
+                  <Image src="/icons/telegram.svg" alt="Telegram" width={16} height={16} loading="eager" />
                 </a>
               </div>
             </div>
@@ -340,7 +340,7 @@ export default function StickyHeader({ initialCategories }: StickyHeaderProps) {
                 width={20}
                 height={20}
                 className="w-5 h-5 text-gray-900 fill-current md:w-7 md:h-7"
-                loading="lazy"
+                loading="eager"
               />
             </button>
 
@@ -357,7 +357,7 @@ export default function StickyHeader({ initialCategories }: StickyHeaderProps) {
                     width={20}
                     height={20}
                     className="w-5 h-5 text-gray-900 fill-current md:w-7 md:h-7 md:hidden"
-                    loading="lazy"
+                    loading="eager"
                   />
                   <div className="hidden md:flex items-center gap-2">
                     {bonus !== null && bonus >= 0 && (
@@ -412,7 +412,7 @@ export default function StickyHeader({ initialCategories }: StickyHeaderProps) {
                   width={20}
                   height={20}
                   className="w-5 h-5 text-gray-900 fill-current md:w-7 md:h-7 md:hidden"
-                  loading="lazy"
+                  loading="eager"
                 />
                 <span className="hidden md:inline">Вход</span>
               </Link>
@@ -432,7 +432,7 @@ export default function StickyHeader({ initialCategories }: StickyHeaderProps) {
                   width={20}
                   height={20}
                   className={`w-5 h-5 fill-current md:w-7 md:h-7 ${totalItems > 0 ? 'text-rose-500' : 'text-gray-900'}`}
-                  loading="lazy"
+                  loading="eager"
                 />
                 {totalItems > 0 && (
                   <span className="absolute -top-2 -right-2 bg-rose-500 text-white text-xs font-semibold rounded-full w-6 h-6 flex items-center justify-center shadow-sm border border-white md:-top-2 md:-right-2">
@@ -488,7 +488,7 @@ export default function StickyHeader({ initialCategories }: StickyHeaderProps) {
                 transition={{ duration: 0.2, delay: 0.1 }}
                 aria-label="Закрыть поиск"
               >
-                <Image src="/icons/x.svg" alt="Закрыть" width={24} height={24} loading="lazy" />
+                <Image src="/icons/x.svg" alt="Закрыть" width={24} height={24} loading="eager" />
               </motion.button>
             </div>
           </motion.div>


### PR DESCRIPTION
## Summary
- set dynamic loading for ProductCard images
- eagerly load icons in the sticky header
- update Payment, Delivery, and Contacts pages to load hero images eagerly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844b27c9e408320a4c37ee79f8c0df9