### PR TITLE
Fix passive listeners in menu

### DIFF
--- a/components/BurgerMenu.tsx
+++ b/components/BurgerMenu.tsx
@@ -42,13 +42,13 @@ export default function BurgerMenu() {
     };
 
     if (menu) {
-      menu.addEventListener('touchstart', onTouchStart);
-      menu.addEventListener('touchend', onTouchEnd);
+      menu.addEventListener('touchstart', onTouchStart, { passive: true });
+      menu.addEventListener('touchend', onTouchEnd, { passive: true });
     }
     return () => {
       if (menu) {
-        menu.removeEventListener('touchstart', onTouchStart);
-        menu.removeEventListener('touchend', onTouchEnd);
+        menu.removeEventListener('touchstart', onTouchStart, { passive: true });
+        menu.removeEventListener('touchend', onTouchEnd, { passive: true });
       }
     };
   }, []);


### PR DESCRIPTION
## Summary
- use passive listeners for menu touch events

## Testing
- `npm run lint` *(fails: various eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844b3ed5a808320b1bc2b7d93abec74