### PR TITLE
Restore Yandex Turbo script

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -257,7 +257,7 @@ export default async function RootLayout({
             {`
               (function() {
                 var turboScript = document.createElement('script');
-                turboScript.src = 'https://cdn.turbo.yandex.ru/turbo.js';
+                turboScript.src = 'https://yastatic.net/s3/turbo-widget/v3/turbo.esm.min.js';
                 turboScript.async = true;
                 document.head.appendChild(turboScript);
               })();


### PR DESCRIPTION
## Summary
- add back the Yandex Turbo `<Script>` and point it to the working URL

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b5e93b64832099a5e401bfe16cf6