### PR TITLE
Add headingId to CategoryPreview components

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -210,6 +210,7 @@ export default async function Home() {
                   categoryName={category}
                   products={items}
                   seeMoreLink={slug}
+                  headingId={`category-preview-${slug || idx}`}
                 />
                 {/* Преимущества после первой категории */}
                 {idx === 0 && <AdvantagesClient />}

--- a/components/CategoryPreview.tsx
+++ b/components/CategoryPreview.tsx
@@ -9,6 +9,7 @@ interface Props {
   products: Product[];
   seeMoreLink: string;
   isVisible: boolean; // Добавляем параметр isVisible
+  headingId: string; // ID заголовка для aria
 }
 
 export default function CategoryPreview({
@@ -16,6 +17,7 @@ export default function CategoryPreview({
   products,
   seeMoreLink,
   isVisible,
+  headingId,
 }: Props) {
   // Если категория не видима, не отображаем её
   if (!isVisible) {
@@ -32,10 +34,10 @@ export default function CategoryPreview({
   return (
     <section
       className="max-w-7xl mx-auto px-4 py-12"
-      aria-labelledby="category-preview-title"
+      aria-labelledby={headingId}
     >
       <h2
-        id="category-preview-title"
+        id={headingId}
         className="text-2xl md:text-3xl font-bold text-center mb-8"
       >
         {categoryName}

--- a/components/CategoryPreviewClient.tsx
+++ b/components/CategoryPreviewClient.tsx
@@ -8,10 +8,12 @@ export default function CategoryPreviewClient({
   categoryName,
   products,
   seeMoreLink,
+  headingId,
 }: {
   categoryName: string;
   products: Product[];
   seeMoreLink: string;
+  headingId: string;
 }) {
   const visibleProducts = products
     .filter((product) => product.in_stock !== false)
@@ -23,10 +25,10 @@ export default function CategoryPreviewClient({
   return (
     <section
       className="max-w-7xl mx-auto px-4 py-12"
-      aria-labelledby="category-preview-title"
+      aria-labelledby={headingId}
     >
       <h2
-        id="category-preview-title"
+        id={headingId}
         className="text-2xl md:text-3xl font-bold text-center mb-8 font-sans uppercase"
       >
         {categoryName}

--- a/components/CategoryPreviewWrapper.tsx
+++ b/components/CategoryPreviewWrapper.tsx
@@ -8,15 +8,24 @@ export default function CategoryPreviewWrapper({
   categoryName,
   products,
   seeMoreLink,
+  headingId,
 }: {
   categoryName: string;
   products: Product[];
   seeMoreLink: string;
+  headingId: string;
 }) {
   const transformedProducts = products.map((product) => ({
     ...product,
     images: product.images || [], // Гарантируем, что images всегда массив
   }));
 
-  return <CategoryPreviewClient categoryName={categoryName} products={transformedProducts} seeMoreLink={seeMoreLink} />;
+  return (
+    <CategoryPreviewClient
+      categoryName={categoryName}
+      products={transformedProducts}
+      seeMoreLink={seeMoreLink}
+      headingId={headingId}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- pass headingId to CategoryPreviewClient and CategoryPreview
- forward headingId in CategoryPreviewWrapper
- provide unique headingId when rendering on home page

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844b89be82c832099afca6a1fc6b3fa