### PR TITLE
Fix BurgerMenu touch listener types

### DIFF
--- a/components/BurgerMenu.tsx
+++ b/components/BurgerMenu.tsx
@@ -34,7 +34,9 @@ export default function BurgerMenu() {
     let startX = 0;
     const menu = menuRef.current;
 
-    const onTouchStart = (e: TouchEvent) => (startX = e.touches[0].clientX);
+    const onTouchStart = (e: TouchEvent) => {
+      startX = e.touches[0].clientX;
+    };
     const onTouchEnd = (e: TouchEvent) => {
       if (startX - e.changedTouches[0].clientX > 50) {
         setIsOpen(false);
@@ -47,8 +49,8 @@ export default function BurgerMenu() {
     }
     return () => {
       if (menu) {
-        menu.removeEventListener('touchstart', onTouchStart, { passive: true });
-        menu.removeEventListener('touchend', onTouchEnd, { passive: true });
+        menu.removeEventListener('touchstart', onTouchStart);
+        menu.removeEventListener('touchend', onTouchEnd);
       }
     };
   }, []);


### PR DESCRIPTION
## Summary
- avoid returning a value from `onTouchStart`
- remove unsupported options from `removeEventListener`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6844bb047b188320b6c2ade9f2a733d8