### PR TITLE
Switch category and promo sections to server render

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import type { ItemList } from 'schema-dts';
 import PromoGrid from '@components/PromoGrid';
 import AdvantagesClient from '@components/AdvantagesClient'; // <-- импорт Client версии
 import PopularProductsServer from '@components/PopularProductsServer';
-import CategoryPreviewWrapper from '@components/CategoryPreviewWrapper';
+import CategoryPreviewServer from '@components/CategoryPreviewServer';
 import SkeletonCard from '@components/ProductCardSkeleton';
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
@@ -206,7 +206,7 @@ export default async function Home() {
 
             return (
               <React.Fragment key={category}>
-                <CategoryPreviewWrapper
+                <CategoryPreviewServer
                   categoryName={category}
                   products={items}
                   seeMoreLink={slug}

--- a/components/CategoryPreviewServer.tsx
+++ b/components/CategoryPreviewServer.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link';
+import ProductCardServer from './ProductCardServer';
+import type { Product } from '@/types/product';
+
+interface Props {
+  categoryName: string;
+  products: Product[];
+  seeMoreLink: string;
+  headingId: string;
+}
+
+export default function CategoryPreviewServer({
+  categoryName,
+  products,
+  seeMoreLink,
+  headingId,
+}: Props) {
+  const visibleProducts = products
+    .filter((product) => product.in_stock !== false)
+    .map((product) => ({ ...product, images: product.images || [] }));
+
+  return (
+    <section className="max-w-7xl mx-auto px-4 py-12" aria-labelledby={headingId}>
+      <h2
+        id={headingId}
+        className="text-2xl md:text-3xl font-bold text-center mb-8 font-sans uppercase"
+      >
+        {categoryName}
+      </h2>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
+        {visibleProducts.map((product, idx) => (
+          <ProductCardServer key={product.id} product={product} priority={idx < 2} />
+        ))}
+      </div>
+      <div className="text-center mt-6">
+        <Link
+          href={`/category/${seeMoreLink}`}
+          className="text-black hover:underline font-medium font-sans uppercase"
+        >
+          —ПОКАЗАТЬ ЕЩЕ—
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/components/ProductCardClient.tsx
+++ b/components/ProductCardClient.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useCart } from '@context/CartContext';
+import { useCartAnimation } from '@context/CartAnimationContext';
+import { ShoppingCart } from 'lucide-react';
+import { useRef } from 'react';
+
+interface Props {
+  id: number;
+  title: string;
+  price: number;
+  imageUrl: string;
+}
+
+export default function ProductCardClient({ id, title, price, imageUrl }: Props) {
+  const { addItem } = useCart();
+  const { triggerCartAnimation } = useCartAnimation();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const handleClick = () => {
+    addItem({ id: id.toString(), title, price, quantity: 1, imageUrl });
+    if (buttonRef.current) {
+      const r = buttonRef.current.getBoundingClientRect();
+      triggerCartAnimation(r.left + r.width / 2, r.top + r.height / 2, imageUrl);
+    }
+  };
+
+  return (
+    <button
+      ref={buttonRef}
+      onClick={handleClick}
+      className="mt-2 sm:mt-auto flex items-center justify-center gap-1.5 sm:gap-2 border border-gray-300 rounded-lg px-4 py-3 font-bold text-sm uppercase bg-white text-black transition-all duration-200 hover:bg-black hover:text-white active:scale-95 w-full"
+      aria-label={`Добавить ${title} в корзину`}
+    >
+      <ShoppingCart size={19} /> В корзину
+    </button>
+  );
+}

--- a/components/ProductCardServer.tsx
+++ b/components/ProductCardServer.tsx
@@ -1,0 +1,94 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import ProductCardClient from './ProductCardClient';
+import type { Product } from '@/types/product';
+
+interface Props {
+  product: Product;
+  priority?: boolean;
+}
+
+export default function ProductCardServer({ product, priority = false }: Props) {
+  const images = Array.isArray(product.images) ? product.images : [];
+  const imageUrl = images[0] || '/placeholder.jpg';
+  const bonus = product.bonus ?? Math.floor(product.price * 0.025);
+  const discountPercent = product.discount_percent ?? 0;
+  const originalPrice = product.original_price || product.price;
+  const discountedPrice = discountPercent
+    ? Math.round(product.price * (1 - discountPercent / 100))
+    : product.price;
+  const discountAmount = discountPercent
+    ? (originalPrice > product.price ? originalPrice : product.price) - discountedPrice
+    : 0;
+  const isPopular = product.is_popular;
+
+  return (
+    <div
+      className="relative flex flex-col w-full max-w-[220px] sm:max-w-[280px] mx-auto bg-white rounded-lg border border-gray-200 overflow-hidden shadow-sm h-auto sm:h-[400px]"
+      role="article"
+      aria-labelledby={`product-${product.id}-title`}
+    >
+      {bonus > 0 && (
+        <div className="absolute top-2 left-2 z-20 flex items-center px-2 py-1 bg-white rounded-full shadow text-[11px] font-semibold text-black border border-gray-100">
+          +{bonus}₽
+        </div>
+      )}
+      {isPopular && (
+        <div className="absolute top-2 right-2 z-20 bg-black text-white text-[10px] sm:text-sm px-2 py-0.5 rounded-full flex items-center font-bold">
+          <span className="mr-1">★</span>Популярно
+        </div>
+      )}
+      <Link
+        href={`/product/${product.id}`}
+        className="block relative w-full h-56 sm:h-64 rounded-t-lg overflow-hidden aspect-[3/4]"
+        aria-label={`Перейти к товару ${product.title}`}
+      >
+        <Image
+          src={imageUrl}
+          alt={product.title}
+          fill
+          className="object-cover w-full h-full"
+          sizes="(max-width: 640px) 100vw, 280px"
+          loading={priority ? 'eager' : 'lazy'}
+          priority={priority}
+        />
+      </Link>
+      <div className="flex flex-col flex-1 p-3 sm:p-4 min-h-[140px] sm:min-h-[160px]">
+        <h3
+          id={`product-${product.id}-title`}
+          className="text-sm sm:text-[15px] font-medium text-black text-center line-clamp-2 break-words"
+        >
+          {product.title}
+        </h3>
+        <div className="flex flex-col items-center mt-2 sm:mt-3">
+          {discountAmount > 0 ? (
+            <>
+              <div className="flex items-center mb-1">
+                <span className="text-xs sm:text-sm text-gray-400 line-through mr-1 sm:mr-2">
+                  {originalPrice > product.price ? originalPrice : product.price}₽
+                </span>
+                <span className="bg-black text-white rounded-md px-1.5 sm:px-2 py-0.5 text-[10px] sm:text-xs font-bold">
+                  -{discountAmount}₽
+                </span>
+              </div>
+              <span className="text-lg sm:text-2xl font-bold text-black">{discountedPrice}₽</span>
+            </>
+          ) : originalPrice > product.price ? (
+            <>
+              <span className="text-xs sm:text-sm text-gray-400 line-through">{originalPrice}₽</span>
+              <span className="text-lg sm:text-2xl font-bold text-black">{product.price}₽</span>
+            </>
+          ) : (
+            <span className="text-lg sm:text-2xl font-bold text-black">{product.price}₽</span>
+          )}
+        </div>
+        <ProductCardClient
+          id={product.id}
+          title={product.title}
+          price={discountedPrice}
+          imageUrl={imageUrl}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/PromoGridWrapper.tsx
+++ b/components/PromoGridWrapper.tsx
@@ -1,8 +1,5 @@
-'use client';
-
-import dynamic from 'next/dynamic';
-
-const PromoGridClient = dynamic(() => import('@components/PromoGridClient'));
+import Image from 'next/image';
+import Link from 'next/link';
 
 interface Block {
   id: number;
@@ -15,5 +12,79 @@ interface Block {
 }
 
 export default function PromoGridWrapper({ banners, cards }: { banners: Block[]; cards: Block[] }) {
-  return <PromoGridClient banners={banners} cards={cards} />;
+  if (!banners.length && !cards.length) return null;
+
+  return (
+    <section
+      className="mx-auto mt-8 sm:mt-10 max-w-7xl px-4 sm:px-6 lg:px-8"
+      aria-labelledby="promo-grid-title"
+    >
+      <h2 id="promo-grid-title" className="sr-only">
+        Промо-блоки
+      </h2>
+      <div className="grid grid-cols-1 gap-4 sm:gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-4">
+          {banners.map((b, i) => (
+            <Link
+              key={b.id}
+              href={b.href || '#'}
+              className="relative block overflow-hidden rounded-2xl lg:rounded-3xl"
+              title={b.title}
+              style={{ aspectRatio: '3 / 2' }}
+            >
+              <Image
+                src={b.image_url}
+                alt={b.title}
+                fill
+                sizes="100vw"
+                priority={i === 0}
+                className="object-cover"
+              />
+              <div className="absolute inset-0 bg-black/20 rounded-2xl lg:rounded-3xl" />
+              <div className="absolute inset-0 flex flex-col justify-center items-start px-4 py-4 sm:px-12 lg:px-16 sm:py-8 lg:py-12 text-white">
+                <div className="max-w-full w-full">
+                  <h2 className="mb-2 text-lg xs:text-xl sm:text-3xl lg:text-4xl font-bold text-white max-w-[95vw] sm:max-w-[80vw] leading-tight">
+                    {b.title}
+                  </h2>
+                  {b.subtitle && (
+                    <p className="mb-3 text-sm xs:text-base sm:text-lg text-white/90 max-w-[95vw] sm:max-w-[80vw]">
+                      {b.subtitle}
+                    </p>
+                  )}
+                  {b.button_text && (
+                    <span className="inline-flex items-center border border-[#bdbdbd] rounded-lg px-3 sm:px-4 lg:px-6 py-1.5 sm:py-2 lg:py-3 font-bold text-xs sm:text-sm lg:text-base uppercase tracking-tight bg-white text-[#535353]">
+                      {b.button_text}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+        <div className="hidden lg:grid grid-cols-2 grid-rows-2 gap-4">
+          {cards.slice(0, 4).map((c) => (
+            <Link
+              key={c.id}
+              href={c.href}
+              className="relative w-full h-full overflow-hidden rounded-2xl lg:rounded-3xl aspect-[3/2]"
+              title={c.title}
+              role="button"
+            >
+              <Image
+                src={c.image_url}
+                alt={c.title}
+                fill
+                sizes="33vw"
+                className="object-cover rounded-2xl lg:rounded-3xl"
+              />
+              <div className="absolute inset-0 bg-black/10 rounded-2xl lg:rounded-3xl" />
+              <span className="absolute bottom-3 left-3 z-10 max-w-[90%] truncate rounded-full bg-white/80 px-2.5 py-1 text-xs lg:text-sm font-semibold text-black shadow-sm line-clamp-1">
+                {c.title}
+              </span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
 }


### PR DESCRIPTION
## Summary
- add server `ProductCardServer` with small client button component
- render categories with new `CategoryPreviewServer`
- convert promo grid wrapper to a server component
- update home page to use server rendered preview

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684550119adc83208d280201e0db3e1e