### PR TITLE
Update docs for server components

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Without this value the `/api/upsell/products` endpoint will return an error.
 
 ## Components
 
-### CategoryPreviewWrapper
+### CategoryPreviewServer
 
-`CategoryPreviewWrapper` is a thin client wrapper around `CategoryPreviewClient` that prepares product data. The file lives in `components/CategoryPreviewWrapper.tsx` and includes the `'use client'` directive.
+`CategoryPreviewServer` is rendered on the server and maps incoming product data to the server-side card component. It lives in `components/CategoryPreviewServer.tsx` and outputs the category heading together with a "see more" link.
+
+### ProductCardServer
+
+`ProductCardServer` renders the static markup for a product card and delegates the "Add to Cart" logic to `ProductCardClient`. Only this small interactive piece includes the `'use client'` directive.


### PR DESCRIPTION
## Summary
- update README to mention `CategoryPreviewServer` and `ProductCardServer`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: prisma client not generated)*

------
https://chatgpt.com/codex/tasks/task_e_684555de482c83208b23c6ed0d54f85b