### PR TITLE
Fix PromoGridWrapper dynamic import

### DIFF
--- a/components/PromoGridWrapper.tsx
+++ b/components/PromoGridWrapper.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import dynamic from 'next/dynamic';
 
 const PromoGridClient = dynamic(() => import('./PromoGridClient'), { ssr: false });


### PR DESCRIPTION
## Summary
- mark `PromoGridWrapper` as a client component so dynamic import with `ssr: false` is valid

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455e38a1d08320b831ab71375cd207