### PR TITLE
Use shared Prisma client in API routes

### DIFF
--- a/app/api/account/bonuses/route.ts
+++ b/app/api/account/bonuses/route.ts
@@ -1,9 +1,8 @@
 // ✅ Путь: app/api/account/bonuses/route.ts
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 import sanitizeHtml from 'sanitize-html';
 
-const prisma = new PrismaClient();
 
 export async function GET(request: Request) {
   process.env.NODE_ENV !== "production" && console.log('Received GET request to /api/account/bonuses:', request.url);

--- a/app/api/account/create-profile/route.ts
+++ b/app/api/account/create-profile/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 export async function POST(request: Request) {
   try {

--- a/app/api/account/expire-bonuses/route.ts
+++ b/app/api/account/expire-bonuses/route.ts
@@ -1,8 +1,7 @@
 // ✅ Путь: app/api/account/expire-bonuses/route.ts
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 const BONUS_EXPIRE_DAYS = 180; // 6 месяцев
 
 export async function POST(request: Request) {

--- a/app/api/account/get-profile/route.ts
+++ b/app/api/account/get-profile/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 export async function POST(request: Request) {
   try {

--- a/app/api/account/important-dates/route.ts
+++ b/app/api/account/important-dates/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 import sanitizeHtml from 'sanitize-html';
 
-const prisma = new PrismaClient();
 
 export async function POST(request: Request) {
   try {

--- a/app/api/account/orders/route.ts
+++ b/app/api/account/orders/route.ts
@@ -1,10 +1,9 @@
 // app/api/account/orders/route.ts
 
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 import sanitizeHtml from 'sanitize-html';
 
-const prisma = new PrismaClient();
 
 export async function GET(req: Request) {
   try {

--- a/app/api/account/profile/route.ts
+++ b/app/api/account/profile/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 import sanitizeHtml from 'sanitize-html';
 
-const prisma = new PrismaClient();
 
 const normalizePhone = (phone: string): string => {
   const cleanPhone = phone.replace(/\D/g, '');

--- a/app/api/account/update-loyalty/route.ts
+++ b/app/api/account/update-loyalty/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 import sanitizeHtml from 'sanitize-html';
 
-const prisma = new PrismaClient();
 
 export async function POST(request: Request) {
   try {

--- a/app/api/account/update-profile/route.ts
+++ b/app/api/account/update-profile/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 export async function POST(request: Request) {
   try {

--- a/app/api/admin/products/toggle-stock/route.ts
+++ b/app/api/admin/products/toggle-stock/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 import { revalidateTag } from 'next/cache';
 
-const prisma = new PrismaClient();
 
 export async function POST(req: NextRequest) {
   const { id } = await req.json();

--- a/app/api/auth/send-call/route.ts
+++ b/app/api/auth/send-call/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 export async function POST(req: Request) {
   try {

--- a/app/api/auth/verify-call/route.ts
+++ b/app/api/auth/verify-call/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
 import jwt from 'jsonwebtoken';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 const SMS_RU_API_ID = process.env.SMS_RU_API_ID!;
 const JWT_SECRET = process.env.JWT_SECRET!;

--- a/app/api/bonuses/route.ts
+++ b/app/api/bonuses/route.ts
@@ -1,9 +1,8 @@
 // app/api/bonuses/route.ts
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 import sanitizeHtml from 'sanitize-html';
 
-const prisma = new PrismaClient();
 
 export async function GET(request: Request) {
   try {

--- a/app/api/check-bonuses/route.ts
+++ b/app/api/check-bonuses/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 export async function POST(request: Request) {
   try {

--- a/app/api/check-promocode/route.ts
+++ b/app/api/check-promocode/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 export async function POST(req: Request) {
   const { code } = await req.json();

--- a/app/api/promo-codes/route.ts
+++ b/app/api/promo-codes/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 export async function GET() {
   try {

--- a/app/api/promo/validate/route.ts
+++ b/app/api/promo/validate/route.ts
@@ -1,8 +1,7 @@
 // ✅ Путь: app/api/promo/validate/route.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 export async function POST(req: NextRequest) {
   try {

--- a/app/api/site-pages/route.ts
+++ b/app/api/site-pages/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 export async function GET() {
   try {


### PR DESCRIPTION
## Summary
- refactor API routes to import the shared Prisma client from `@/lib/prisma`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f45259608320838669a00225734e