### PR TITLE
Improve a11y for promo grid and burger menu

### DIFF
--- a/components/BurgerMenu.tsx
+++ b/components/BurgerMenu.tsx
@@ -98,7 +98,11 @@ export default function BurgerMenu() {
           </button>
         </div>
 
-        <nav className="p-4 space-y-1" aria-label="Основная навигация">
+        <nav
+          className="p-4 space-y-1"
+          aria-label="Основная навигация"
+          aria-hidden={!isOpen}
+        >
           {navLinks.map((link, idx) => (
             <Link
               key={idx}
@@ -114,6 +118,7 @@ export default function BurgerMenu() {
                 });
               }}
               className="block py-2 text-black hover:bg-gray-100 transition-colors"
+              tabIndex={isOpen ? 0 : -1}
             >
               {link.name}
             </Link>

--- a/components/PromoGridClient.tsx
+++ b/components/PromoGridClient.tsx
@@ -70,7 +70,7 @@ export default function PromoGridClient({
                   <Link href={b.href || '#'} className="relative block h-full w-full" title={b.title}>
                     <WebpImage
                       src={b.image_url}
-                      alt={b.title}
+                      alt=""
                       fill
                       sizes="(max-width: 1024px) 100vw, 66vw"
                       priority={i === 0}
@@ -135,7 +135,7 @@ export default function PromoGridClient({
                   <Link href={item.href || '#'} className="relative block h-full w-full" title={item.title}>
                     <WebpImage
                       src={item.image_url}
-                      alt={item.title}
+                      alt=""
                       fill
                       sizes="100vw"
                       priority={i === 0}
@@ -207,7 +207,7 @@ export default function PromoGridClient({
               <Link href={c.href} className="group block h-full w-full" title={c.title} role="button">
                 <WebpImage
                   src={c.image_url}
-                  alt={c.title}
+                  alt=""
                   fill
                   sizes="(max-width: 1024px) 50vw, 33vw"
                   className="object-cover transition-transform duration-300 group-hover:scale-105 rounded-2xl lg:rounded-3xl"


### PR DESCRIPTION
## Summary
- fix burger menu links focus when closed
- mark promo grid images as decorative

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845f9cb4a288320b2650810f1867733