### PR TITLE
Fix top bar marquee duplication

### DIFF
--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -18,16 +18,15 @@ export default function TopBar() {
             aria-roledescription="marquee"
             aria-label="Информационная панель"
           >
-            {[...Array(30)].flatMap((_, i) =>
-              textItems.map((text, idx) => (
-                <span key={`${i}-${idx}`} className="mx-6">
-                  {text}
-                </span>
-              ))
-            )}
+            {[...textItems, ...textItems].map((text, idx) => (
+              <span key={idx} className="mx-6">
+                {text}
+              </span>
+            ))}
           </div>
         </div>
       </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- remove huge `[...Array(30)]` repetition from TopBar
- only output two copies of the text for smooth marquee animation

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npx lighthouse` *(fails: package not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_6845fe753e1083209908371596b738bb