### PR TITLE
Limit eager image loading to one item

### DIFF
--- a/components/CategoryPreviewServer.tsx
+++ b/components/CategoryPreviewServer.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import ProductCardServer from './ProductCardServer';
 import type { Product } from '@/types/product';
+import { claimPriority } from '@/utils/imagePriority';
 
 interface Props {
   categoryName: string;
@@ -28,9 +29,16 @@ export default function CategoryPreviewServer({
         {categoryName}
       </h2>
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
-        {visibleProducts.map((product, idx) => (
-          <ProductCardServer key={product.id} product={product} priority={idx < 2} />
-        ))}
+        {visibleProducts.map((product, idx) => {
+          const shouldPrioritize = idx === 0 && claimPriority();
+          return (
+            <ProductCardServer
+              key={product.id}
+              product={product}
+              priority={shouldPrioritize}
+            />
+          );
+        })}
       </div>
       <div className="text-center mt-6">
         <Link

--- a/components/PopularProductsClient.tsx
+++ b/components/PopularProductsClient.tsx
@@ -6,6 +6,7 @@ import 'swiper/css';
 import 'swiper/css/navigation';
 import ProductCard from '@components/ProductCard';
 import { Product } from '@/types/product';
+import { claimPriority } from '@/utils/imagePriority';
 import Image from 'next/image';
 
 export default function PopularProductsClient({ products }: { products: Product[] }) {
@@ -44,11 +45,14 @@ export default function PopularProductsClient({ products }: { products: Product[
           }}
           className="group"
         >
-          {prepared.map((p, idx) => (
-            <SwiperSlide key={p.id} className="flex justify-center">
-              <ProductCard product={p} priority={idx < 2} />
-            </SwiperSlide>
-          ))}
+          {prepared.map((p, idx) => {
+            const shouldPrioritize = idx === 0 && claimPriority();
+            return (
+              <SwiperSlide key={p.id} className="flex justify-center">
+                <ProductCard product={p} priority={shouldPrioritize} />
+              </SwiperSlide>
+            );
+          })}
           <button
             className="popular-prev absolute left-0 top-1/2 z-10 -translate-y-1/2 rounded-full bg-white p-3 shadow hover:scale-110 transition-transform duration-300 focus:outline-none focus:ring-2 focus:ring-black"
             aria-label="Прокрутить популярные товары влево"

--- a/utils/imagePriority.ts
+++ b/utils/imagePriority.ts
@@ -1,0 +1,14 @@
+let priorityClaimed = false;
+
+export function claimPriority(): boolean {
+  if (!priorityClaimed) {
+    priorityClaimed = true;
+    return true;
+  }
+  return false;
+}
+
+export function resetPriority() {
+  priorityClaimed = false;
+}
+


### PR DESCRIPTION
## Summary
- add utility for tracking image priority
- use the tracker in PopularProductsClient to only load the first image eagerly
- update CategoryPreviewServer to claim priority for its first image only

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ffb5d67c8320ab9ec41410ce2b87