### PR TITLE
Fix mobile loop init

### DIFF
--- a/components/PromoGridClient.tsx
+++ b/components/PromoGridClient.tsx
@@ -30,10 +30,9 @@ export default function PromoGridClient({
   const desktopBanners = banners.slice(0, 5);
   const desktopCards = cards.slice(0, 4);
   const bannerLoop = desktopBanners.length > 1;
-  const mobileLoop = mobileItems.length > 1;
-
   // Мобайл: баннеры и карточки вместе
   const mobileItems = [...banners, ...cards];
+  const mobileLoop = mobileItems.length > 1;
 
   const textVariants = {
     hidden: { opacity: 0, y: 20 },


### PR DESCRIPTION
## Summary
- compute mobile items before referencing them in PromoGridClient

## Testing
- `npx tsc --noEmit >/tmp/tsc.log && grep -n "PromoGridClient" -n /tmp/tsc.log`

------
https://chatgpt.com/codex/tasks/task_e_684ed7d964e48320984e2f8a7d06a827