### PR TITLE
Fix Add to Cart animation for category previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Without `SUPABASE_SERVICE_ROLE_KEY` the `/api/upsell/products` endpoint will ret
 
 ### CategoryPreviewServer
 
-`CategoryPreviewServer` is rendered on the server and maps incoming product data to the server-side card component. It lives in `components/CategoryPreviewServer.tsx` and outputs the category heading together with a "see more" link.
+`CategoryPreviewServer` is rendered on the server and outputs the category heading together with a "see more" link. Product cards are rendered using the interactive `ProductCard` component so the "Add to Cart" button appears on hover.
 
 ### ProductCardServer
 

--- a/components/CategoryPreviewServer.tsx
+++ b/components/CategoryPreviewServer.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import ProductCardServer from './ProductCardServer';
+import ProductCard from './ProductCard';
 import type { Product } from '@/types/product';
 import { claimPriority } from '@/utils/imagePriority';
 
@@ -32,7 +32,7 @@ export default function CategoryPreviewServer({
         {visibleProducts.map((product, idx) => {
           const shouldPrioritize = idx === 0 && claimPriority();
           return (
-            <ProductCardServer
+            <ProductCard
               key={product.id}
               product={product}
               priority={shouldPrioritize}


### PR DESCRIPTION
## Summary
- use the same interactive `ProductCard` in `CategoryPreviewServer`
- document new behaviour in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684edb8c37248320a9a690847fd73202