### PR TITLE
Fix Yandex Metrica script init

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -187,11 +187,16 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         {ymId && (
           <Script id="ym" strategy="lazyOnload">
             {`
-              (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
-              m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0];
-              k.async=1;k.src=r;a.parentNode.insertBefore(k,a)})
-              (window,document,"script","https://mc.yandex.ru/metrika/tag.js","ym");
-              ym("${ymId}", "init", {clickmap:true,trackLinks:true,accurateTrackBounce:true,trackHash:true,webvisor:true});
+              (function(m,e,t,r,i,k,a){
+                m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+                m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+                k.async=1;k.src=r;a.parentNode.insertBefore(k,a)
+              })(window,document,"script","https://mc.yandex.ru/metrika/tag.js","ym");
+              if (typeof ym === 'function') {
+                ym("${ymId}", "init", {clickmap:true,trackLinks:true,accurateTrackBounce:true,trackHash:true,webvisor:true});
+              } else {
+                console.warn('Yandex.Metrica script is not loaded');
+              }
             `}
           </Script>
         )}


### PR DESCRIPTION
## Summary
- ensure we only initialise Yandex Metrica if the script exposes `ym`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684edcbce9448320956380e5a3180964