### PR TITLE
Fix TopBar whitespace

### DIFF
--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -25,8 +25,7 @@ export default function TopBar() {
         aria-label="Информационная панель"
       >
         {/* одна и та же строка дважды подряд — никакого зазора на стыке */}
-        <span>{STRIP}</span>
-        <span aria-hidden="true">{STRIP}</span>
+        <span>{STRIP}</span><span aria-hidden="true">{STRIP}</span>
       </motion.div>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove newline between TopBar scrolling spans so React doesn't insert whitespace

## Testing
- `npm install`
- `npm run build` *(fails: @prisma/client did not initialize)*
- `npm run dev` *(runs but fetches fail due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684f04d475e88320a519e5a60a17cb53