### PR TITLE
Fix promo management

### DIFF
--- a/app/admin/(protected)/promo/page.tsx
+++ b/app/admin/(protected)/promo/page.tsx
@@ -47,7 +47,7 @@ export default function PromoAdminPage() {
 
   async function fetchBlocks() {
     try {
-      const res = await fetch('/api/promo/blocks'); // Предполагаемый эндпоинт для получения блоков
+      const res = await fetch('/api/promo');
       const data = await res.json();
       setBlocks(data);
     } catch (err: any) {
@@ -105,7 +105,11 @@ export default function PromoAdminPage() {
   async function handleDelete(id: number) {
     if (!confirm('Удалить блок?')) return;
     try {
-      const res = await fetch(`/api/promo/blocks/${id}`, { method: 'DELETE' });
+      const res = await fetch('/api/promo', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id }),
+      });
       if (!res.ok) throw new Error('Ошибка удаления');
       toast.success('Блок удалён');
       fetchBlocks();
@@ -135,6 +139,7 @@ export default function PromoAdminPage() {
         method: 'POST',
         body: formData,
         credentials: 'include',
+        headers: { 'X-CSRF-Token': csrfToken },
       });
 
       const data = await res.json();

--- a/app/api/promo/reorder/route.ts
+++ b/app/api/promo/reorder/route.ts
@@ -1,6 +1,6 @@
 // ✅ Путь: app/api/promo/reorder/route.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { supabaseAdmin } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
 
 export async function POST(req: NextRequest) {
   try {
@@ -10,19 +10,10 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Некорректный формат данных' }, { status: 400 });
     }
 
-    // Обновляем order_index в Supabase
     const updates = order.map(({ id, order_index }: { id: number; order_index: number }) =>
-      supabaseAdmin
-        .from('promo_blocks')
-        .update({ order_index })
-        .eq('id', id)
+      prisma.promo_blocks.update({ where: { id }, data: { order_index } })
     );
-
-    const results = await Promise.all(updates);
-    const errors = results.filter(result => result.error);
-    if (errors.length > 0) {
-      throw new Error(errors[0].error?.message || 'Ошибка обновления порядка');
-    }
+    await Promise.all(updates);
 
     return NextResponse.json({ success: true });
   } catch (error: any) {

--- a/app/api/promo/upload-image/route.ts
+++ b/app/api/promo/upload-image/route.ts
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest) {
 
     // Загружаем в Supabase Storage
     const { error } = await supabase.storage
-      .from('product-image')
+      .from('promo-images')
       .upload(filename, optimizedImage, {
         contentType: 'image/webp',
         upsert: true
@@ -57,14 +57,14 @@ export async function POST(req: NextRequest) {
     }
 
     // Формируем публичный URL
-    const image_url = `${supabaseUrl}/storage/v1/object/public/product-image/${filename}`;
+    const image_url = `${supabaseUrl}/storage/v1/object/public/promo-images/${filename}`;
 
     // Удаляем старое изображение если оно на Supabase
-    if (oldImageUrl && oldImageUrl.includes('product-image/')) {
-      const parts = oldImageUrl.split('product-image/');
+    if (oldImageUrl && oldImageUrl.includes('promo-images/')) {
+      const parts = oldImageUrl.split('promo-images/');
       const oldFile = parts[1];
       if (oldFile) {
-        await supabase.storage.from('product-image').remove([oldFile]);
+        await supabase.storage.from('promo-images').remove([oldFile]);
       }
     }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import React from 'react'; // <-- обязательно для <React.Fragment>
 import { Metadata } from 'next';
 import { JsonLd } from 'react-schemaorg';
 import type { ItemList } from 'schema-dts';
-import PromoGrid from '@components/PromoGrid';
+import PromoGridServer from '@components/PromoGridServer';
 import AdvantagesClient from '@components/AdvantagesClient'; // <-- импорт Client версии
 import PopularProductsServer from '@components/PopularProductsServer';
 import CategoryPreviewServer from '@components/CategoryPreviewServer';
@@ -184,7 +184,7 @@ export default async function Home() {
         }}
       />
       <section>
-        <PromoGrid />
+        <PromoGridServer />
       </section>
       <section>
         <PopularProductsServer />

--- a/components/PromoGridServer.tsx
+++ b/components/PromoGridServer.tsx
@@ -1,0 +1,34 @@
+import PromoGridWrapper from '@components/PromoGridWrapper';
+
+interface Block {
+  id: number;
+  title: string;
+  subtitle?: string | null;
+  href: string;
+  image_url: string;
+  type: 'card' | 'banner';
+  button_text?: string | null;
+  order_index?: number | null;
+}
+
+export default async function PromoGridServer() {
+  try {
+    const baseUrl =
+      process.env.NEXT_PUBLIC_BASE_URL ||
+      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
+    const res = await fetch(`${baseUrl}/api/promo`, { next: { revalidate: 60 } });
+    if (!res.ok) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('PromoGridServer fetch error:', await res.text());
+      }
+      return null;
+    }
+    const data: Block[] = await res.json();
+    const banners = data.filter((b) => b.type === 'banner');
+    const cards = data.filter((b) => b.type === 'card');
+    return <PromoGridWrapper banners={banners} cards={cards} />;
+  } catch (err) {
+    process.env.NODE_ENV !== 'production' && console.error('PromoGridServer error:', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- fetch promo blocks correctly in admin UI and use CSRF header
- add server component for promo grid
- show promo grid on homepage via server component
- use Prisma when reordering blocks
- fix promo image upload bucket and CSRF check

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1db9655c832094ddac81634f528e