### PR TITLE
Create shared PromoBlock type

### DIFF
--- a/components/PromoGridClient.tsx
+++ b/components/PromoGridClient.tsx
@@ -10,22 +10,14 @@ import { Autoplay, Pagination } from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/pagination';
 
-interface Block {
-  id: number;
-  title: string;
-  subtitle?: string;
-  href: string;
-  image_url: string;
-  type: 'card' | 'banner';
-  button_text?: string;
-}
+import { PromoBlock } from '@/types/promo';
 
 export default function PromoGridClient({
   banners,
   cards,
 }: {
-  banners: Block[];
-  cards: Block[];
+  banners: PromoBlock[];
+  cards: PromoBlock[];
 }) {
   const [activeSlide, setActiveSlide] = useState(0);
 

--- a/components/PromoGridServer.tsx
+++ b/components/PromoGridServer.tsx
@@ -1,15 +1,5 @@
 import PromoGridWrapper from '@components/PromoGridWrapper';
-
-interface Block {
-  id: number;
-  title: string;
-  subtitle?: string | null;
-  href: string;
-  image_url: string;
-  type: 'card' | 'banner';
-  button_text?: string | null;
-  order_index?: number | null;
-}
+import { PromoBlock } from '@/types/promo';
 
 export default async function PromoGridServer() {
   try {
@@ -23,7 +13,7 @@ export default async function PromoGridServer() {
       }
       return null;
     }
-    const data: Block[] = await res.json();
+    const data: PromoBlock[] = await res.json();
     const banners = data.filter((b) => b.type === 'banner');
     const cards = data.filter((b) => b.type === 'card');
     return <PromoGridWrapper banners={banners} cards={cards} />;

--- a/components/PromoGridWrapper.tsx
+++ b/components/PromoGridWrapper.tsx
@@ -3,23 +3,14 @@
 import dynamic from 'next/dynamic';
 
 const PromoGridClient = dynamic(() => import('./PromoGridClient'), { ssr: false });
-
-interface Block {
-  id: number;
-  title: string;
-  subtitle?: string;
-  href: string;
-  image_url: string;
-  type: 'card' | 'banner';
-  button_text?: string;
-}
+import { PromoBlock } from '@/types/promo';
 
 export default function PromoGridWrapper({
   banners,
   cards,
 }: {
-  banners: Block[];
-  cards: Block[];
+  banners: PromoBlock[];
+  cards: PromoBlock[];
 }) {
   if (!banners.length && !cards.length) return null;
 

--- a/types/promo.ts
+++ b/types/promo.ts
@@ -1,0 +1,10 @@
+export interface PromoBlock {
+  id: number;
+  title: string;
+  subtitle?: string | null;
+  href: string;
+  image_url: string;
+  type: 'card' | 'banner';
+  button_text?: string | null;
+  order_index?: number | null;
+}


### PR DESCRIPTION
## Summary
- add new `PromoBlock` interface under `types`
- use new shared type in PromoGrid server, wrapper and client components

## Testing
- `npm install` *(fails: binaries.prisma.sh blocked)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2db356b483208fda1a7220d0933c