### PR TITLE
Enable same-day orders & pass production time

### DIFF
--- a/app/cart/CartPageClient.tsx
+++ b/app/cart/CartPageClient.tsx
@@ -187,7 +187,7 @@ export default function CartPageClient() {
     validateStep5,
     getMinDate,
     resetForm,
-  } = useCheckoutForm();
+  } = useCheckoutForm(storeSettings, maxProductionTime);
 
   const handleStep4ValidationChange = useCallback((isValid: boolean, errorMessage: string) => {
     setIsStep4Valid(isValid);

--- a/app/cart/hooks/useCheckoutForm.ts
+++ b/app/cart/hooks/useCheckoutForm.ts
@@ -4,6 +4,18 @@
 import { useState, useEffect } from 'react';
 import toast from 'react-hot-toast';
 
+interface DaySchedule {
+  start: string;
+  end: string;
+  enabled?: boolean;
+}
+
+interface StoreSettings {
+  order_acceptance_enabled: boolean;
+  order_acceptance_schedule: Record<string, DaySchedule>;
+  store_hours: Record<string, DaySchedule>;
+}
+
 interface FormState {
   phone: string;
   email: string;
@@ -57,7 +69,10 @@ const normalizePhone = (phone: string): string => {
   return phone.startsWith('+') ? phone : `+${phone}`;
 };
 
-export default function useCheckoutForm() {
+export default function useCheckoutForm(
+  storeSettings?: StoreSettings | null,
+  maxProductionTime?: number | null,
+) {
   const [step, setStep] = useState<0 | 1 | 2 | 3 | 4 | 5>(0);
   const [form, setForm] = useState<FormState>(initialFormState);
   const [phoneError, setPhoneError] = useState<string>('');
@@ -284,8 +299,44 @@ export default function useCheckoutForm() {
 
   const getMinDate = () => {
     const today = new Date();
-    today.setDate(today.getDate() + 1);
-    return today.toISOString().split('T')[0];
+
+    if (storeSettings && storeSettings.order_acceptance_enabled) {
+      for (let i = 0; i < 7; i++) {
+        const date = new Date(today);
+        date.setDate(today.getDate() + i);
+        const dayKey = date
+          .toLocaleString('en-US', { weekday: 'long' })
+          .toLowerCase();
+        const orderDay = storeSettings.order_acceptance_schedule[dayKey];
+        const storeDay = storeSettings.store_hours[dayKey];
+        const isEnabled =
+          orderDay?.enabled !== false && storeDay?.enabled !== false;
+
+        if (!isEnabled) continue;
+
+        if (i === 0) {
+          // today - check cutoff time
+          const latestEnd = (orderDay.end < storeDay.end
+            ? orderDay.end
+            : storeDay.end) as string;
+          const [h, m] = latestEnd.split(':').map(Number);
+          const cutoff = new Date(today);
+          cutoff.setHours(h, m, 0, 0);
+          if (maxProductionTime != null) {
+            cutoff.setHours(cutoff.getHours() - maxProductionTime);
+          }
+          if (today <= cutoff) {
+            return today.toISOString().split('T')[0];
+          }
+        } else {
+          return date.toISOString().split('T')[0];
+        }
+      }
+    }
+
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    return tomorrow.toISOString().split('T')[0];
   };
 
   const resetForm = () => {

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -55,6 +55,7 @@ export default function ProductCard({
       price: discountedPrice,
       quantity: 1,
       imageUrl,
+      production_time: product.production_time ?? null,
     });
 
     if (isMobile && buttonRef.current) {
@@ -166,6 +167,16 @@ export default function ProductCard({
             {discountAmount > 0 ? discountedPrice : product.price}₽
           </span>
         </div>
+
+        {product.production_time != null && (
+          <div className="flex items-center justify-center gap-1 text-xs text-gray-600 mb-1">
+            <Image src="/icons/clock.svg" alt="" width={14} height={14} />
+            <span>
+              Время изготовления: {product.production_time}{' '}
+              {product.production_time === 1 ? 'час' : 'часов'}
+            </span>
+          </div>
+        )}
 
         {/* --- Кнопка/блок "В корзину" --- */}
         <AnimatePresence>

--- a/components/ProductCardClient.tsx
+++ b/components/ProductCardClient.tsx
@@ -10,15 +10,23 @@ interface Props {
   title: string;
   price: number;
   imageUrl: string;
+  productionTime?: number | null;
 }
 
-export default function ProductCardClient({ id, title, price, imageUrl }: Props) {
+export default function ProductCardClient({ id, title, price, imageUrl, productionTime }: Props) {
   const { addItem } = useCart();
   const { triggerCartAnimation } = useCartAnimation();
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   const handleClick = () => {
-    addItem({ id: id.toString(), title, price, quantity: 1, imageUrl });
+    addItem({
+      id: id.toString(),
+      title,
+      price,
+      quantity: 1,
+      imageUrl,
+      production_time: productionTime,
+    });
     if (buttonRef.current) {
       const r = buttonRef.current.getBoundingClientRect();
       triggerCartAnimation(r.left + r.width / 2, r.top + r.height / 2, imageUrl);

--- a/components/ProductCardServer.tsx
+++ b/components/ProductCardServer.tsx
@@ -82,11 +82,22 @@ export default function ProductCardServer({ product, priority = false }: Props) 
             <span className="text-lg sm:text-2xl font-bold text-black">{product.price}₽</span>
           )}
         </div>
+
+        {product.production_time != null && (
+          <div className="flex items-center mt-1 text-xs text-gray-600">
+            <Image src="/icons/clock.svg" alt="" width={16} height={16} className="mr-1" />
+            <span>
+              Время изготовления: {product.production_time}{' '}
+              {product.production_time === 1 ? 'час' : 'часов'}
+            </span>
+          </div>
+        )}
         <ProductCardClient
           id={product.id}
           title={product.title}
           price={discountedPrice}
           imageUrl={imageUrl}
+          productionTime={product.production_time ?? null}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- compute minimum checkout date based on store hours and product production time
- allow checkout hook to receive store settings
- display production time on catalog cards
- pass production time when adding products to cart

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68503a22691083208b34ca7e22f2611f