### PR TITLE
Fix production time on homepage and improve breadcrumbs

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -235,7 +235,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             <StickyHeader initialCategories={categories} />
 
             <Suspense fallback={<div>Загрузка…</div>}>
-              <ClientBreadcrumbs />
+              <ClientBreadcrumbs initialCategories={categories} />
             </Suspense>
 
             <main id="main-content" tabIndex={-1} className="pt-12 sm:pt-14">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ interface Product {
   discount_percent: number | null;
   in_stock: boolean;
   images: string[];
+  production_time: number | null;
   category_ids: number[];
 }
 
@@ -90,7 +91,8 @@ export default async function Home() {
         price,
         discount_percent,
         in_stock,
-        images
+        images,
+        production_time
       `)
       .in('id', productIds.length > 0 ? productIds : [0]) // Избегаем пустого IN
       .eq('in_stock', true)
@@ -107,6 +109,7 @@ export default async function Home() {
           discount_percent: item.discount_percent ?? null,
           in_stock: item.in_stock ?? false,
           images: item.images ?? [],
+          production_time: item.production_time ?? null,
           category_ids: productCategoriesMap.get(item.id) || [],
         }))
       : [];

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -53,12 +53,18 @@ const generateSlug = (name: string) =>
     .replace(/(^-|-$)/g, '')
     .replace(/-+/g, '-');
 
-function Breadcrumbs({ productTitle }: { productTitle?: string }) {
+function Breadcrumbs({
+  productTitle,
+  initialCategories = [],
+}: {
+  productTitle?: string;
+  initialCategories?: Category[];
+}) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const subcategorySlug = searchParams.get('subcategory') || 'all';
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [categories, setCategories] = useState<Category[]>(initialCategories);
+  const [loading, setLoading] = useState(initialCategories.length === 0);
 
   const fetchCategories = async () => {
     try {
@@ -112,7 +118,13 @@ function Breadcrumbs({ productTitle }: { productTitle?: string }) {
   };
 
   useEffect(() => {
-    fetchCategories();
+    if (initialCategories.length === 0) {
+      fetchCategories();
+    } else {
+      categoryCache = initialCategories;
+      setCategories(initialCategories);
+      setLoading(false);
+    }
 
     const channel = supabase
       .channel('categories-subcategories-changes-breadcrumbs')
@@ -139,7 +151,7 @@ function Breadcrumbs({ productTitle }: { productTitle?: string }) {
     return () => {
       supabase.removeChannel(channel);
     };
-  }, []);
+  }, [initialCategories]);
 
   const crumbs: Crumb[] = [];
   crumbs.push({ href: '/', label: 'Главная' });

--- a/components/ClientBreadcrumbs.tsx
+++ b/components/ClientBreadcrumbs.tsx
@@ -3,10 +3,10 @@
 
 import Breadcrumbs from './Breadcrumbs';
 import { usePathname } from 'next/navigation';
-
-export default function ClientBreadcrumbs() {
+import type { Category } from '@/types/category';
+export default function ClientBreadcrumbs({ initialCategories }: { initialCategories: Category[] }) {
   const pathname = usePathname();
   const isProductPage = pathname.startsWith('/product/');
 
-  return !isProductPage ? <Breadcrumbs /> : null;
+  return !isProductPage ? <Breadcrumbs initialCategories={initialCategories} /> : null;
 }


### PR DESCRIPTION
## Summary
- include `production_time` in homepage product data
- show manufacturing time on category previews
- pass initial category data to breadcrumbs for faster load

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685151d872888320b388ad1d0054026c