### PR TITLE
Fix production time on homepage and improve breadcrumbs

### DIFF
--- a/app/api/popular/route.ts
+++ b/app/api/popular/route.ts
@@ -13,6 +13,7 @@ interface PopularProduct {
   is_popular: boolean | null;
   is_visible: boolean | null;
   order_index: number | null;
+  production_time: number | null;
 }
 
 export async function GET() {
@@ -20,7 +21,7 @@ export async function GET() {
     // Получаем товары из Supabase
     const { data, error } = await supabaseAdmin
       .from('products')
-      .select('id, title, price, original_price, discount_percent, in_stock, images, is_popular, is_visible, order_index')
+      .select('id, title, price, original_price, discount_percent, in_stock, images, is_popular, is_visible, order_index, production_time')
       .eq('in_stock', true)
       .eq('is_popular', true)
       .eq('is_visible', true)
@@ -49,6 +50,8 @@ export async function GET() {
       is_popular: product.is_popular,
       is_visible: product.is_visible,
       order_index: product.order_index !== null ? Number(product.order_index) : null,
+      production_time:
+        product.production_time !== null ? Number(product.production_time) : null,
     }));
 
     return NextResponse.json(formattedData, {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -235,7 +235,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             <StickyHeader initialCategories={categories} />
 
             <Suspense fallback={<div>Загрузка…</div>}>
-              <ClientBreadcrumbs />
+              <ClientBreadcrumbs initialCategories={categories} />
             </Suspense>
 
             <main id="main-content" tabIndex={-1} className="pt-12 sm:pt-14">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ interface Product {
   discount_percent: number | null;
   in_stock: boolean;
   images: string[];
+  production_time: number | null;
   category_ids: number[];
 }
 
@@ -90,7 +91,8 @@ export default async function Home() {
         price,
         discount_percent,
         in_stock,
-        images
+        images,
+        production_time
       `)
       .in('id', productIds.length > 0 ? productIds : [0]) // Избегаем пустого IN
       .eq('in_stock', true)
@@ -107,6 +109,7 @@ export default async function Home() {
           discount_percent: item.discount_percent ?? null,
           in_stock: item.in_stock ?? false,
           images: item.images ?? [],
+          production_time: item.production_time ?? null,
           category_ids: productCategoriesMap.get(item.id) || [],
         }))
       : [];

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -53,12 +53,18 @@ const generateSlug = (name: string) =>
     .replace(/(^-|-$)/g, '')
     .replace(/-+/g, '-');
 
-function Breadcrumbs({ productTitle }: { productTitle?: string }) {
+function Breadcrumbs({
+  productTitle,
+  initialCategories = [],
+}: {
+  productTitle?: string;
+  initialCategories?: Category[];
+}) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const subcategorySlug = searchParams.get('subcategory') || 'all';
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [categories, setCategories] = useState<Category[]>(initialCategories);
+  const [loading, setLoading] = useState(initialCategories.length === 0);
 
   const fetchCategories = async () => {
     try {
@@ -112,7 +118,13 @@ function Breadcrumbs({ productTitle }: { productTitle?: string }) {
   };
 
   useEffect(() => {
-    fetchCategories();
+    if (initialCategories.length === 0) {
+      fetchCategories();
+    } else {
+      categoryCache = initialCategories;
+      setCategories(initialCategories);
+      setLoading(false);
+    }
 
     const channel = supabase
       .channel('categories-subcategories-changes-breadcrumbs')
@@ -139,7 +151,7 @@ function Breadcrumbs({ productTitle }: { productTitle?: string }) {
     return () => {
       supabase.removeChannel(channel);
     };
-  }, []);
+  }, [initialCategories]);
 
   const crumbs: Crumb[] = [];
   crumbs.push({ href: '/', label: 'Главная' });

--- a/components/ClientBreadcrumbs.tsx
+++ b/components/ClientBreadcrumbs.tsx
@@ -3,10 +3,10 @@
 
 import Breadcrumbs from './Breadcrumbs';
 import { usePathname } from 'next/navigation';
-
-export default function ClientBreadcrumbs() {
+import type { Category } from '@/types/category';
+export default function ClientBreadcrumbs({ initialCategories }: { initialCategories: Category[] }) {
   const pathname = usePathname();
   const isProductPage = pathname.startsWith('/product/');
 
-  return !isProductPage ? <Breadcrumbs /> : null;
+  return !isProductPage ? <Breadcrumbs initialCategories={initialCategories} /> : null;
 }

--- a/components/PopularProductsClient.tsx
+++ b/components/PopularProductsClient.tsx
@@ -22,6 +22,7 @@ export default function PopularProductsClient({ products }: { products: Product[
     ...item,
     images: item.images || [],
     category_ids: item.category_ids || [],
+    production_time: item.production_time ?? null,
   }));
 
   const enableLoop = prepared.length > 4;

--- a/components/PopularProductsServer.tsx
+++ b/components/PopularProductsServer.tsx
@@ -19,6 +19,7 @@ export default async function PopularProductsServer() {
       ...item,
       images: item.images || [],
       category_ids: item.category_ids || [],
+      production_time: item.production_time ?? null,
     }));
     return <PopularProductsClient products={products} />;
   } catch (err) {


### PR DESCRIPTION
## Summary
- include `production_time` in popular products API and components
- show manufacturing time on category previews
- pass initial category data to breadcrumbs for faster load

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685151d872888320b388ad1d0054026c