### PR TITLE
Normalize visibility flags for categories

### DIFF
--- a/app/admin/(protected)/categories/page.tsx
+++ b/app/admin/(protected)/categories/page.tsx
@@ -41,7 +41,7 @@ export default async function CategoriesPage() {
   let categories: Category[] = [];
 
   try {
-    categories = await prisma.categories.findMany({
+    const categoriesData = await prisma.categories.findMany({
       orderBy: { id: 'asc' },
       select: {
         id: true,
@@ -60,6 +60,14 @@ export default async function CategoriesPage() {
         },
       },
     });
+    categories = categoriesData.map((cat) => ({
+      ...cat,
+      is_visible: cat.is_visible ?? true,
+      subcategories: cat.subcategories.map((sub) => ({
+        ...sub,
+        is_visible: sub.is_visible ?? true,
+      })),
+    }));
   } catch (error: any) {
     process.env.NODE_ENV !== "production" && console.error('Error fetching categories:', error.message);
   }


### PR DESCRIPTION
## Summary
- normalize visibility fields for categories and subcategories when loading admin category page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516e01256c8320aba84e2f60ab2277