### PR TITLE
Remove async cookies helper

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -18,7 +18,7 @@ interface BonusesData {
 
 export default async function AccountPage() {
   // Получаем куки с телефоном
-  const cookieStore = await cookies();
+  const cookieStore = cookies();
   const phone = cookieStore.get('user_phone')?.value ?? '';
 
   // Сессия

--- a/app/admin/(protected)/categories/page.tsx
+++ b/app/admin/(protected)/categories/page.tsx
@@ -21,7 +21,7 @@ interface Category {
 }
 
 export default async function CategoriesPage() {
-  const cookieStore = await cookies();
+  const cookieStore = cookies();
 
   // Проверяем admin_session токен
   const token = cookieStore.get('admin_session')?.value;

--- a/app/admin/(protected)/customers/[id]/page.tsx
+++ b/app/admin/(protected)/customers/[id]/page.tsx
@@ -26,7 +26,7 @@ interface PageProps {
 }
 
 export default async function CustomerPage({ params }: PageProps) {
-  const cookieStore = await cookies();
+  const cookieStore = cookies();
   const token = cookieStore.get('admin_session')?.value;
 
   if (!token) {

--- a/app/admin/(protected)/customers/page.tsx
+++ b/app/admin/(protected)/customers/page.tsx
@@ -49,7 +49,7 @@ interface Customer {
 }
 
 export default async function CustomersPage() {
-  const cookieStore = await cookies();
+  const cookieStore = cookies();
   const token = cookieStore.get('admin_session')?.value;
 
   if (!token) {

--- a/app/admin/(protected)/orders/page.tsx
+++ b/app/admin/(protected)/orders/page.tsx
@@ -57,7 +57,7 @@ export default async function AdminOrdersPage() {
   }
 
   // Проверка сессии
-  const cookieStore = await cookies();
+  const cookieStore = cookies();
   const token = cookieStore.get('admin_session')?.value;
   if (!token) {
     redirect('/admin/login?error=no-session');

--- a/app/api/clear-supabase-cookies/route.ts
+++ b/app/api/clear-supabase-cookies/route.ts
@@ -3,8 +3,8 @@ import { cookies } from 'next/headers';
 
 export async function POST() {
   try {
-    // Добавляем await для получения объекта cookies
-    const cookieStore = await cookies();
+    // Получаем объект cookies
+    const cookieStore = cookies();
 
     // Удаляем все cookies, начинающиеся с 'sb-'
     for (const cookie of cookieStore.getAll()) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,7 +42,7 @@ export const metadata: Metadata = {
 };
 
 export default async function Home() {
-  const cookieStore = await cookies();
+  const cookieStore = cookies();
   const supabase = createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -4,7 +4,7 @@ import { cookies } from 'next/headers';
 import { revalidatePath } from 'next/cache';
 
 export async function createSupabaseServerClient() {
-  const cookieStore = await cookies();
+  const cookieStore = cookies();
 
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
## Summary
- call `cookies()` synchronously across the app
- update outdated comment in the clear-cookies route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516e01e3348320853d6c7d8b60a4aa