### PR TITLE
Refactor category types

### DIFF
--- a/app/admin/(protected)/categories/CategoriesClient.tsx
+++ b/app/admin/(protected)/categories/CategoriesClient.tsx
@@ -12,21 +12,7 @@ import {
   deleteSubcategory,
 } from './actions';
 
-interface Subcategory {
-  id: number;
-  name: string;
-  category_id: number | null;
-  slug: string;
-  is_visible: boolean;
-}
-
-interface Category {
-  id: number;
-  name: string;
-  slug: string;
-  is_visible: boolean;
-  subcategories: Subcategory[];
-}
+import type { Category, Subcategory } from '@/types/category';
 
 interface Props {
   categories: Category[];

--- a/app/admin/(protected)/categories/page.tsx
+++ b/app/admin/(protected)/categories/page.tsx
@@ -3,22 +3,7 @@ import { redirect } from 'next/navigation';
 import { prisma } from '@/lib/prisma';
 import { verifyAdminJwt } from '@/lib/auth';
 import CategoriesClient from './CategoriesClient';
-
-interface Subcategory {
-  id: number;
-  name: string;
-  category_id: number | null;
-  slug: string;
-  is_visible: boolean;
-}
-
-interface Category {
-  id: number;
-  name: string;
-  slug: string;
-  is_visible: boolean;
-  subcategories: Subcategory[];
-}
+import type { Category } from '@/types/category';
 
 export default async function CategoriesPage() {
   const cookieStore = await cookies();

--- a/app/admin/(protected)/products/ProductTable.tsx
+++ b/app/admin/(protected)/products/ProductTable.tsx
@@ -24,6 +24,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { GripVertical, Edit, Trash2 } from 'lucide-react';
 import toast from 'react-hot-toast';
+import type { Category } from '@/types/category';
 
 interface Product {
   id: number;
@@ -39,10 +40,6 @@ interface Product {
   category_ids: number[];
 }
 
-interface Category {
-  id: number;
-  name: string;
-}
 
 type ViewMode = 'table' | 'cards';
 

--- a/app/admin/(protected)/products/[id]/page.tsx
+++ b/app/admin/(protected)/products/[id]/page.tsx
@@ -13,6 +13,7 @@ import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable } 
 import { CSS } from '@dnd-kit/utilities';
 import { GripVertical, Trash2 } from 'lucide-react';
 import Image from 'next/image';
+import type { Category, Subcategory } from '@/types/category';
 
 type Product = {
   id: number;
@@ -37,17 +38,6 @@ type Product = {
   subcategory_ids: number[];
 };
 
-interface Category {
-  id: number;
-  name: string;
-  slug: string;
-}
-
-interface Subcategory {
-  id: number;
-  name: string;
-  category_id: number | null;
-}
 
 interface ImageFile {
   id: string;

--- a/app/admin/(protected)/products/new/page.tsx
+++ b/app/admin/(protected)/products/new/page.tsx
@@ -9,18 +9,7 @@ import CSRFToken from '@components/CSRFToken';
 import Compressor from 'compressorjs';
 import { motion } from 'framer-motion';
 import Image from 'next/image';
-
-interface Category {
-  id: number;
-  name: string;
-  slug: string;
-}
-
-interface Subcategory {
-  id: number;
-  name: string;
-  category_id: number | null;
-}
+import type { Category, Subcategory } from '@/types/category';
 
 interface ImageFile {
   id: string;

--- a/app/admin/(protected)/products/page.tsx
+++ b/app/admin/(protected)/products/page.tsx
@@ -9,6 +9,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import SitePagesDropdown from '../components/SitePagesDropdown';
 import ProductTable from './ProductTable';
 import type { Database } from '@/lib/supabase/types_new';
+import type { Category } from '@/types/category';
 
 // Интерфейс Product
 interface Product {
@@ -34,11 +35,6 @@ interface Product {
 }
 
 export type ViewMode = 'table' | 'cards';
-
-interface Category {
-  id: number;
-  name: string;
-}
 
 const queryClient = new QueryClient();
 

--- a/types/category.ts
+++ b/types/category.ts
@@ -1,12 +1,16 @@
+export type Subcategory = {
+  id: number;
+  name: string;
+  slug: string;
+  is_visible: boolean;
+  category_id?: number | null;
+  label?: string | null;
+};
+
 export type Category = {
   id: number;
   name: string;
   slug: string;
   is_visible: boolean;
-  subcategories: {
-    id: number;
-    name: string;
-    slug: string;
-    is_visible: boolean;
-  }[];
+  subcategories: Subcategory[];
 };


### PR DESCRIPTION
## Summary
- export `Subcategory` and make optional fields
- share `Category` and `Subcategory` types in admin pages

## Testing
- `npm run lint` *(fails: Next.js not found or other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68516e0388e4832086091dd6a04906d5