### PR TITLE
Fix parameter typing

### DIFF
--- a/app/admin/(protected)/customers/[id]/page.tsx
+++ b/app/admin/(protected)/customers/[id]/page.tsx
@@ -22,7 +22,7 @@ interface Customer {
 }
 
 interface PageProps {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 export default async function CustomerPage({ params }: PageProps) {
@@ -38,8 +38,8 @@ export default async function CustomerPage({ params }: PageProps) {
     redirect('/admin/login?error=invalid-session');
   }
 
-  // Распаковываем params с помощью await
-  const { id } = await params;
+  // Распаковываем params
+  const { id } = params;
 
   let customer: Customer | null = null;
   try {

--- a/app/category/[category]/[subcategorySlug]/page.tsx
+++ b/app/category/[category]/[subcategorySlug]/page.tsx
@@ -4,11 +4,11 @@ export default async function SubcategoryRedirect({
   params,
   searchParams,
 }: {
-  params: Promise<{ category: string; subcategorySlug: string }>;
-  searchParams: Promise<{ sort?: string }>;
+  params: { category: string; subcategorySlug: string };
+  searchParams: { sort?: string };
 }) {
-  const { category, subcategorySlug } = await params;
-  const { sort = 'newest' } = await searchParams;
+  const { category, subcategorySlug } = params;
+  const { sort = 'newest' } = searchParams;
 
   // Перенаправляем на страницу категории с параметром subcategory
   redirect(`/category/${category}?sort=${sort}&subcategory=${subcategorySlug}`);

--- a/app/category/[category]/page.tsx
+++ b/app/category/[category]/page.tsx
@@ -77,9 +77,9 @@ const nameMap: Record<string, string> = {
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ category: string }>;
+  params: { category: string };
 }): Promise<Metadata> {
-  const { category } = await params;
+  const { category } = params;
   const name = nameMap[category] ?? 'Категория';
 
   return {
@@ -101,11 +101,11 @@ export default async function CategoryPage({
   params,
   searchParams,
 }: {
-  params: Promise<{ category: string }>;
-  searchParams: Promise<{ sort?: string; subcategory?: string }>;
+  params: { category: string };
+  searchParams: { sort?: string; subcategory?: string };
 }) {
-  const { category } = await params;
-  const { sort = 'newest', subcategory: initialSubcategory = 'all' } = await searchParams;
+  const { category } = params;
+  const { sort = 'newest', subcategory: initialSubcategory = 'all' } = searchParams;
 
   const apiName = nameMap[category];
 


### PR DESCRIPTION
## Summary
- stop using Promise-wrapped `params` and `searchParams`
- simplify param handling in several pages

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851757601f48320a6095a9a3db07b64