### PR TITLE
Fix occasion query

### DIFF
--- a/app/admin/(protected)/categories/page.tsx
+++ b/app/admin/(protected)/categories/page.tsx
@@ -26,7 +26,7 @@ export default async function CategoriesPage() {
   let categories: Category[] = [];
 
   try {
-    const categoriesData = await prisma.categories.findMany({
+    const categoriesData: any[] = await prisma.categories.findMany({
       orderBy: { id: 'asc' },
       select: {
         id: true,
@@ -45,10 +45,10 @@ export default async function CategoriesPage() {
         },
       },
     });
-    categories = categoriesData.map((cat) => ({
+    categories = categoriesData.map((cat: any) => ({
       ...cat,
       is_visible: cat.is_visible ?? true,
-      subcategories: cat.subcategories.map((sub) => ({
+      subcategories: cat.subcategories.map((sub: any) => ({
         ...sub,
         is_visible: sub.is_visible ?? true,
       })),

--- a/app/admin/(protected)/products/page.tsx
+++ b/app/admin/(protected)/products/page.tsx
@@ -40,7 +40,7 @@ export default async function ProductsPage() {
       },
     });
 
-    products = rows.map(r => ({
+    products = rows.map((r: any) => ({
       id: r.id,
       title: r.title ?? '',
       price: r.price ?? 0,
@@ -56,7 +56,7 @@ export default async function ProductsPage() {
       is_visible: r.is_visible ?? false,
       is_popular: r.is_popular ?? false,
       order_index: r.order_index ?? 0,
-      category_ids: r.product_categories.map(pc => pc.category_id),
+      category_ids: r.product_categories.map((pc: any) => pc.category_id),
       bonus: r.bonus !== null && r.bonus !== undefined ? Number(r.bonus) : null,
       composition: r.composition ?? null,
       created_at: r.created_at ? r.created_at.toISOString() : null,
@@ -75,7 +75,7 @@ export default async function ProductsPage() {
       select: { id: true, name: true, slug: true },
       orderBy: { name: 'asc' },
     });
-    categories = cats.map(c => ({ id: c.id, name: c.name, slug: c.slug }));
+    categories = cats.map((c: any) => ({ id: c.id, name: c.name, slug: c.slug }));
   } catch (error) {
     process.env.NODE_ENV !== 'production' && console.error('Error fetching categories:', error);
   }

--- a/app/occasions/[slug]/page.tsx
+++ b/app/occasions/[slug]/page.tsx
@@ -152,7 +152,15 @@ export default async function OccasionDetailPage({
   }
 
   const data = await prisma.products.findMany({
-    where: { occasion_slug: params.slug, in_stock: true },
+    where: {
+      in_stock: true,
+      is_visible: true,
+      product_subcategories: {
+        some: {
+          subcategories: { slug: params.slug },
+        },
+      },
+    },
     select: {
       id: true,
       title: true,


### PR DESCRIPTION
## Summary
- fetch occasion products via product_subcategories join table
- add explicit `any` typing in admin pages to satisfy strict TypeScript

## Testing
- `npx prisma generate` *(fails: Failed to fetch sha256 checksum)*
- `npx next build` *(fails to compile due to TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851807a3f80832092892ed926b83fc4