### PR TITLE
Add React Query provider for admin

### DIFF
--- a/app/admin/(protected)/layout.tsx
+++ b/app/admin/(protected)/layout.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import { useState } from 'react';
+import ReactQueryProvider from '@/app/providers/ReactQueryProvider';
 import Link from 'next/link';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -26,7 +27,8 @@ export default function AdminProtectedLayout({
   ];
 
   return (
-    <div className="flex min-h-screen bg-gray-50">
+    <ReactQueryProvider>
+      <div className="flex min-h-screen bg-gray-50">
       {/* Desktop sidebar */}
       <motion.aside
         className="w-64 bg-white border-r p-6 hidden md:block"
@@ -151,5 +153,6 @@ export default function AdminProtectedLayout({
       {/* Main content */}
       <main className="flex-1 p-6 bg-white overflow-auto">{children}</main>
     </div>
+    </ReactQueryProvider>
   );
 }

--- a/app/providers/ReactQueryProvider.tsx
+++ b/app/providers/ReactQueryProvider.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode, useState } from 'react';
+
+export default function ReactQueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}


### PR DESCRIPTION
## Summary
- add `ReactQueryProvider` to initialize a `QueryClient`
- wrap admin pages in `ReactQueryProvider`

## Testing
- `npm run lint` *(fails: many eslint errors)*
- `npm run build` *(fails: module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68518a02c3e48320ba5af04fc6e3d446