### PR TITLE
Fix admin session URL in delete handler

### DIFF
--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -712,7 +712,8 @@ export async function PATCH(req: NextRequest) {
 export async function DELETE(req: NextRequest) {
   try {
     process.env.NODE_ENV !== "production" && console.log('DELETE /api/products: Starting request');
-    const sessionRes = await fetch(new URL('/api/admin-session', req.url), {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://keytoheart.ru';
+    const sessionRes = await fetch(new URL('/api/admin-session', baseUrl), {
       headers: { cookie: req.headers.get('cookie') || '' },
     });
     const sessionData = await sessionRes.json();


### PR DESCRIPTION
## Summary
- patch `/api/products` DELETE handler to use `NEXT_PUBLIC_BASE_URL` for admin session check

## Testing
- `npm install`
- `npm run lint` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68518caec7088320b2ef78f30b6d7ce5