### PR TITLE
Allow product deletion

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -490,7 +490,7 @@ model order_items {
   quantity   Int
   price      Int
   orders     orders?   @relation(fields: [order_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  products   products? @relation(fields: [product_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  products   products? @relation(fields: [product_id], references: [id], onDelete: SetNull, onUpdate: NoAction)
 
   @@schema("public")
 }


### PR DESCRIPTION
## Summary
- let `product_id` in `order_items` become NULL when a product is deleted

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npx prisma migrate dev --name allow-product-delete` *(fails: 403 Forbidden when downloading engines)*

------
https://chatgpt.com/codex/tasks/task_e_6851900ea5a88320b47ca396575b5f3f