### PR TITLE
Show production time on product cards

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -55,6 +55,7 @@ export default function ProductCard({
       price: discountedPrice,
       quantity: 1,
       imageUrl,
+      production_time: product.production_time ?? null,
     });
 
     if (isMobile && buttonRef.current) {
@@ -166,6 +167,12 @@ export default function ProductCard({
             {discountAmount > 0 ? discountedPrice : product.price}₽
           </span>
         </div>
+        {product.production_time != null && (
+          <p className="text-center text-xs sm:text-sm text-gray-500 mt-1">
+            Время изготовления: {product.production_time}{' '}
+            {product.production_time === 1 ? 'час' : 'часов'}
+          </p>
+        )}
 
         {/* --- Кнопка/блок "В корзину" --- */}
         <AnimatePresence>

--- a/components/ProductCardClient.tsx
+++ b/components/ProductCardClient.tsx
@@ -10,15 +10,23 @@ interface Props {
   title: string;
   price: number;
   imageUrl: string;
+  productionTime: number | null;
 }
 
-export default function ProductCardClient({ id, title, price, imageUrl }: Props) {
+export default function ProductCardClient({ id, title, price, imageUrl, productionTime }: Props) {
   const { addItem } = useCart();
   const { triggerCartAnimation } = useCartAnimation();
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   const handleClick = () => {
-    addItem({ id: id.toString(), title, price, quantity: 1, imageUrl });
+    addItem({
+      id: id.toString(),
+      title,
+      price,
+      quantity: 1,
+      imageUrl,
+      production_time: productionTime,
+    });
     if (buttonRef.current) {
       const r = buttonRef.current.getBoundingClientRect();
       triggerCartAnimation(r.left + r.width / 2, r.top + r.height / 2, imageUrl);

--- a/components/ProductCardServer.tsx
+++ b/components/ProductCardServer.tsx
@@ -82,11 +82,18 @@ export default function ProductCardServer({ product, priority = false }: Props) 
             <span className="text-lg sm:text-2xl font-bold text-black">{product.price}₽</span>
           )}
         </div>
+        {product.production_time != null && (
+          <p className="mt-1 text-xs sm:text-sm text-gray-500 text-center">
+            Время изготовления: {product.production_time}{' '}
+            {product.production_time === 1 ? 'час' : 'часов'}
+          </p>
+        )}
         <ProductCardClient
           id={product.id}
           title={product.title}
           price={discountedPrice}
           imageUrl={imageUrl}
+          productionTime={product.production_time ?? null}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- display production time on `ProductCardServer`
- forward productionTime to `ProductCardClient`
- include production time in the interactive `ProductCard`

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851998ae8688320b8cc1aefc4bd1d0e