### PR TITLE
Add production time to catalog products

### DIFF
--- a/app/catalog/page.tsx
+++ b/app/catalog/page.tsx
@@ -154,6 +154,7 @@ export default async function CatalogPage() {
           composition,
           is_popular,
           is_visible,
+          production_time,
           in_stock
         `)
         .order('id', { ascending: true });
@@ -190,6 +191,7 @@ export default async function CatalogPage() {
           composition: product.composition ?? null,
           is_popular: product.is_popular ?? null,
           is_visible: product.is_visible ?? null,
+          production_time: product.production_time ?? null,
           in_stock: product.in_stock ?? null,
           category_ids: productCategoriesMap.get(product.id) || [],
           subcategory_ids: subcategoryIds,

--- a/components/CatalogClient.tsx
+++ b/components/CatalogClient.tsx
@@ -25,6 +25,7 @@ export interface Product {
   composition?: string | null;
   is_popular?: boolean | null;
   is_visible?: boolean | null;
+  production_time?: number | null;
   category_ids: number[]; // Массив ID категорий
   subcategory_ids: number[]; // Массив ID подкатегорий
   subcategory_names: string[]; // Массив названий подкатегорий


### PR DESCRIPTION
## Summary
- include `production_time` in `Product` interface
- query and return `production_time` from the products table

## Testing
- `npm run lint` *(fails: Expected assignment or function call errors)*

------
https://chatgpt.com/codex/tasks/task_e_68519d54c47083209cd132affa5ec2f7