### PR TITLE
Add error handler for YandexMetrika script

### DIFF
--- a/components/YandexMetrikaScript.tsx
+++ b/components/YandexMetrikaScript.tsx
@@ -28,6 +28,10 @@ export default function YandexMetrikaScript({ ymId }: YandexMetrikaScriptProps) 
           console.error('Yandex Metrika is not loaded');
         }
       }}
-    />
+      // Log if the external script fails to load
+      onError={() =>
+        console.error('Failed to load Yandex.Metrica script')
+      }
+      />
   );
 }


### PR DESCRIPTION
## Summary
- log a message if Yandex.Metrica script fails to load

## Testing
- `npm run lint` *(fails: numerous lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68528619ae008320b265354b794b3fb7