### PR TITLE
Add eager loading for first banner image

### DIFF
--- a/components/PromoGridClient.tsx
+++ b/components/PromoGridClient.tsx
@@ -77,6 +77,8 @@ export default function PromoGridClient({
                         fill
                         sizes="(max-width: 1024px) 100vw, 66vw"
                         priority={i === 0} // Приоритет для первого баннера
+                        loading="eager"
+                        fetchPriority="high"
                         className="object-cover rounded-2xl lg:rounded-3xl"
                         style={{ aspectRatio: '3 / 2' }}
                       />


### PR DESCRIPTION
## Summary
- set eager loading and fetch priority for the first banner image

## Testing
- `npm install`
- `npm run lint` *(fails: many eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863dfde7ac48320a38698f96eca07a5