### PR TITLE
Use dynamic imports for SearchModal and CookieBanner

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,12 @@ import { Suspense } from 'react';
 import TopBar from '@components/TopBar';
 import StickyHeader from '@components/StickyHeader';
 import Footer from '@components/Footer';
-import CookieBanner from '@components/CookieBanner';
+import dynamic from 'next/dynamic';
+
+const CookieBanner = dynamic(() => import('@components/CookieBanner'), {
+  ssr: false,
+  loading: () => null,
+});
 import ClientBreadcrumbs from '@components/ClientBreadcrumbs';
 import PromoFooterBlock from '@components/PromoFooterBlock';
 import MobileContactFab from '@components/MobileContactFab';

--- a/components/StickyHeader.tsx
+++ b/components/StickyHeader.tsx
@@ -5,8 +5,16 @@ import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
 import BurgerMenu from '@components/BurgerMenu';
 import CategoryNav from '@components/CategoryNav';
-import SearchModal from '@components/SearchModal';
-import CookieBanner from '@components/CookieBanner';
+import dynamic from 'next/dynamic';
+
+const SearchModal = dynamic(() => import('@components/SearchModal'), {
+  ssr: false,
+  loading: () => null,
+});
+const CookieBanner = dynamic(() => import('@components/CookieBanner'), {
+  ssr: false,
+  loading: () => null,
+});
 import { useCart } from '@context/CartContext';
 import { useCartAnimation } from '@context/CartAnimationContext';
 import { supabasePublic as supabase } from '@/lib/supabase/public';


### PR DESCRIPTION
## Summary
- wrap SearchModal and CookieBanner with next/dynamic
- reference the dynamic components in StickyHeader and layout

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863e00c901483208c9ccdefca3aeb5e