### PR TITLE
Preload first PromoGrid banner

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,6 +20,7 @@ import { CartProvider } from '@context/CartContext';
 import { CartAnimationProvider } from '@context/CartAnimationContext';
 import { Category } from '@/types/category';
 import { YM_ID } from '@/utils/ym';
+import { getFirstPromoBannerUrl } from '@/lib/promo';
 
 /* ------------------------------------------------------------------ */
 /*                          ШРИФТЫ (next/font)                        */
@@ -121,6 +122,8 @@ export default async function RootLayout({
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
+  const firstBannerUrl = await getFirstPromoBannerUrl();
+
   let categories: Category[] = [];
   try {
     const res = await fetch(
@@ -166,6 +169,14 @@ export default async function RootLayout({
           href="https://gwbeabfkknhewwoesqax.supabase.co"
           crossOrigin="anonymous"
         />
+        {firstBannerUrl && (
+          <link
+            rel="preload"
+            as="image"
+            href={firstBannerUrl}
+            fetchPriority="high"
+          />
+        )}
         <JsonLd
           item={{
             '@context': 'https://schema.org',

--- a/lib/promo.ts
+++ b/lib/promo.ts
@@ -1,0 +1,17 @@
+import { prisma } from './prisma';
+
+export async function getFirstPromoBannerUrl(): Promise<string | null> {
+  try {
+    const firstBanner = await prisma.promo_blocks.findFirst({
+      where: { type: 'banner' },
+      orderBy: { order_index: 'asc' },
+      select: { image_url: true },
+    });
+    return firstBanner?.image_url || null;
+  } catch (err) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('getFirstPromoBannerUrl error:', err);
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add helper to fetch first promo banner
- preload the first PromoGrid banner image in the layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640c0c6fdc83209c761f0f79295744