### PR TITLE
Configure Supabase image caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
 `NEXT_PUBLIC_BASE_URL` is used for admin session checks. Without `SUPABASE_SERVICE_ROLE_KEY` the `/api/upsell/products` endpoint will return an error.
 
+## Supabase Storage Caching
+
+For frequently used images stored in Supabase, enable caching to reduce bandwidth.
+In the Supabase dashboard open your bucket settings and configure a CDN or set
+the `Cache-Control` metadata to `public, max-age=604800`.
+
+
 ## Components
 
 ### CategoryPreviewServer

--- a/app/admin/(protected)/products/[id]/page.tsx
+++ b/app/admin/(protected)/products/[id]/page.tsx
@@ -488,7 +488,9 @@ export default function EditProductPage() {
           process.env.NODE_ENV !== "production" && console.log('Uploading image to Supabase:', fileName);
           const { data, error } = await supabase.storage
             .from('product-image')
-            .upload(fileName, compressedImage);
+            .upload(fileName, compressedImage, {
+              cacheControl: 'public, max-age=604800',
+            });
 
           if (error) {
             throw new Error('Ошибка загрузки изображения: ' + error.message);

--- a/app/admin/(protected)/products/new/page.tsx
+++ b/app/admin/(protected)/products/new/page.tsx
@@ -279,7 +279,9 @@ export default function NewProductPage() {
           const fileName = `${uuidv4()}-${compressedImage.name}`;
           const { error } = await supabase.storage
             .from('product-image')
-            .upload(fileName, compressedImage);
+            .upload(fileName, compressedImage, {
+              cacheControl: 'public, max-age=604800',
+            });
           if (error) throw new Error('Ошибка загрузки изображения: ' + error.message);
           const { data: publicData } = supabase.storage
             .from('product-image')

--- a/app/admin/edit-product/[id]/page.tsx
+++ b/app/admin/edit-product/[id]/page.tsx
@@ -338,7 +338,9 @@ export default function EditProductPage() {
           const fileName = `${uuidv4()}-${compressed.name}`;
           const { error } = await supabase.storage
             .from('product-image')
-            .upload(fileName, compressed);
+            .upload(fileName, compressed, {
+              cacheControl: 'public, max-age=604800',
+            });
           if (error) throw new Error(error.message);
           const { data: publicData } = supabase.storage
             .from('product-image')

--- a/app/api/promo/upload-image/route.ts
+++ b/app/api/promo/upload-image/route.ts
@@ -48,7 +48,8 @@ export async function POST(req: NextRequest) {
       .from('product-image')
       .upload(filename, optimizedImage, {
         contentType: 'image/webp',
-        upsert: true
+        upsert: true,
+        cacheControl: 'public, max-age=604800',
       });
 
     if (error) {

--- a/components/admin/ProductForm.tsx
+++ b/components/admin/ProductForm.tsx
@@ -114,7 +114,9 @@ export default function ProductForm({ product, onClose, onSave }: ProductFormPro
     const fileName = `${Date.now()}.${fileExt}`;
     const { data, error } = await supabasePublic.storage
       .from('products')
-      .upload(fileName, file);
+      .upload(fileName, file, {
+        cacheControl: 'public, max-age=604800',
+      });
 
     if (error) {
       setError('Ошибка при загрузке изображения');


### PR DESCRIPTION
## Summary
- describe how to enable caching for Supabase Storage
- add `cacheControl` headers when uploading images to Supabase

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640fb5ac7c8320b15cd11b40a72c2f