### PR TITLE
Optimize image loading hints

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -179,6 +179,8 @@ export default async function RootLayout({
           href="https://gwbeabfkknhewwoesqax.supabase.co"
           crossOrigin="anonymous"
         />
+        <link rel="preconnect" href="https://mc.yandex.ru" crossOrigin="anonymous" />
+        <link rel="preconnect" href="https://mc.yandex.com" crossOrigin="anonymous" />
         <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
         {/* PWA / favicon extras */}
         <link rel="manifest" href="/site.webmanifest" />

--- a/components/ProductCardClient.tsx
+++ b/components/ProductCardClient.tsx
@@ -57,7 +57,13 @@ export default function ProductCardClient({
     <div className="relative w-full h-full flex flex-col justify-between border border-gray-300 rounded-lg overflow-hidden">
       {/* Содержимое карточки (изображение и текст) */}
       <div className="p-4">
-        <img src={imageUrl} alt={title} className="w-full h-auto" />
+        <img
+          src={imageUrl}
+          alt={title}
+          width={220}
+          height={220}
+          className="w-full h-auto"
+        />
         <div className="mt-2">
           <h3 className="text-sm font-bold">{title}</h3>
           <p className="text-sm">{price}₽</p>

--- a/components/PromoGridClient.tsx
+++ b/components/PromoGridClient.tsx
@@ -89,6 +89,7 @@ export default function PromoGridClient({
                           fill
                           sizes="(max-width: 1024px) 100vw, 66vw"
                           priority={i === 0}
+                          fetchPriority={i === 0 ? 'high' : 'auto'}
                           className="object-cover rounded-2xl lg:rounded-3xl"
                           style={{ aspectRatio: '3 / 2' }}
                         />
@@ -178,6 +179,7 @@ export default function PromoGridClient({
                           fill
                           sizes="100vw"
                           priority={i === 0}
+                          fetchPriority={i === 0 ? 'high' : 'auto'}
                           loading={i === 0 ? 'eager' : 'lazy'}  /* <-- изменено */
                           className="object-cover rounded-2xl"
                           style={{ aspectRatio: '3 / 2' }}
@@ -277,6 +279,7 @@ export default function PromoGridClient({
                     alt={c.title}
                     fill
                     sizes="(max-width: 1024px) 50vw, 33vw"
+                    fetchPriority={i === 0 ? 'high' : 'auto'}
                     className="object-cover transition-transform duration-300 group-hover:scale-105 rounded-2xl lg:rounded-3xl"
                     style={{ aspectRatio: '3 / 2' }}
                   />


### PR DESCRIPTION
## Summary
- bump preconnect for Yandex Metrika
- hint priority for promo images
- define dimensions on client product card images

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d322dc7cc83209719c737e35339be